### PR TITLE
Update ID assignment for GECKO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,26 +112,6 @@ build/%.html: build/%.owl build/%.tsv | build/robot-validate.jar
 	--output-dir build/
 
 
-### Browser
-
-gecko.json: build/gecko.owl | build/robot.jar
-	$(ROBOT) export \
-	--input $< \
-	--header "ID|LABEL|definition|question description|see also|subclasses" \
-	--sort "LABEL" \
-	--export $@
-
-genomics-england.json: build/genomics-england.owl | build/robot.jar
-	$(ROBOT) export \
-	--input $< \
-	--header "ID|LABEL|definition" \
-	--sort "ID|LABEL" \
-	--export $@
-
-serve: index.html gecko.json genomics-england.json
-	python3 -m http.server 8000
-
-
 ### General Tasks
 
 .PHONY: refresh

--- a/src/gecko/index.tsv
+++ b/src/gecko/index.tsv
@@ -1,0 +1,98 @@
+Short ID	Label
+gecko:0000001	basic cohort attributes
+gecko:0000002	aims and objectives
+gecko:0000003	timeline
+gecko:0000004	study design
+gecko:0000005	population data
+gecko:0000006	location
+gecko:0000007	criteria for enrollment and recruitment procedures
+gecko:0000008	num. participants
+gecko:0000009	demographic data
+gecko:0000010	sex(es) studied in cohort
+gecko:0000011	gender(s) studied in cohort
+gecko:0000012	age range
+gecko:0000013	data collection events
+gecko:0000014	biosample
+gecko:0000015	sample type
+gecko:0000016	urine
+gecko:0000017	blood
+gecko:0000018	venous or arterial
+gecko:0000019	fasting or non-fasting
+gecko:0000020	stool
+gecko:0000021	saliva
+gecko:0000043	other
+gecko:0000046	availability
+gecko:0000044	sample size
+gecko:0000047	processing method
+gecko:0000026	storage method
+gecko:0000027	laboratory measures
+gecko:0000028	microbiology
+gecko:0000029	microbial data
+gecko:0000030	biosample source/anatomical location
+gecko:0000045	available data format(s)
+gecko:0000032	genomics
+gecko:0000033	data type
+gecko:0000034	DNA/Genotyping
+gecko:0000035	WGS
+gecko:0000036	WES
+gecko:0000037	Sequence variants
+gecko:0000038	Epigenetics
+gecko:0000039	Metagenomics
+gecko:0000040	Microbiome markers
+gecko:0000041	RNAseq/gene expression
+gecko:0000042	eQTL
+gecko:0000048	associated cell type/tissue type/biosample
+gecko:0000049	associated phenotype
+gecko:0000050	associated disease
+gecko:0000051	associated medication
+gecko:0000052	survey administration
+gecko:0000053	date and time-related information
+gecko:0000054	consent/accessibility
+gecko:0000055	unique identifiers
+gecko:0000056	questionnaire/survey data
+gecko:0000057	socio-demographic and economic characteristics
+gecko:0000058	age/birthdate
+gecko:0000059	biological sex
+gecko:0000060	gender
+gecko:0000061	ethnicity/race
+gecko:0000062	genealogy
+gecko:0000063	birthplace
+gecko:0000064	residence
+gecko:0000065	education
+gecko:0000066	family and household structure
+gecko:0000067	lifestyle and behaviours
+gecko:0000068	tobacco
+gecko:0000069	alcohol
+gecko:0000070	physical activity
+gecko:0000071	sleep
+gecko:0000072	nutrition
+gecko:0000073	physician/practitioner info
+gecko:0000074	diseases
+gecko:0000075	blood-related disorders
+gecko:0000076	endocrine/nutritional/metabolic disorders
+gecko:0000077	mental and behaviour disorders
+gecko:0000078	nervous system
+gecko:0000079	digestive system
+gecko:0000080	respiratory system
+gecko:0000081	circulatory system
+gecko:0000082	oncological
+gecko:0000083	signs and symptoms
+gecko:0000084	physiological measurements
+gecko:0000085	anthropometry
+gecko:0000086	weight
+gecko:0000087	height
+gecko:0000088	circulation and respiration
+gecko:0000089	blood pressure
+gecko:0000090	heart rate
+gecko:0000091	non-pharmacological interventions
+gecko:0000092	surgical interventions
+gecko:0000093	medication
+gecko:0000094	associated disease(s)
+gecko:0000095	prescription
+gecko:0000096	drug response(s)
+gecko:0000097	posology
+gecko:0000098	administration method
+gecko:0000099	life stage/time point
+gecko:0000100	general research data documents
+gecko:0000101	statistics
+gecko:0000102	summary statistics for additional data from federated sources

--- a/src/genomics-england/genomics-england.py
+++ b/src/genomics-england/genomics-england.py
@@ -140,7 +140,7 @@ def main():
         # Create a short ID and write to template
         short_id = re.sub(
             r'_+', '_', category.lower().replace(' ', '_').replace('/', '_').replace(';', '').replace('(', '').replace(
-                ')', ''))
+                ')', '').replace('-', '_'))
         writer.writerow(['ge:' + short_id, category, '', '', 'owl:Thing', '', ''])
 
     # Add the values from the sheet

--- a/src/genomics-england/genomics-england.py
+++ b/src/genomics-england/genomics-england.py
@@ -140,8 +140,8 @@ def main():
         # Create a short ID and write to template
         short_id = re.sub(
             r'_+', '_', category.lower().replace(' ', '_').replace('/', '_').replace(';', '').replace('(', '').replace(
-                ')', '').replace('-', '_'))
-        writer.writerow(['ex:' + short_id, category, '', '', 'owl:Thing', '', ''])
+                ')', ''))
+        writer.writerow(['ge:' + short_id, category, '', '', 'owl:Thing', '', ''])
 
     # Add the values from the sheet
     for short_id in all_ids:
@@ -179,7 +179,10 @@ def main():
         else:
             label = this_labels[0]
 
-        writer.writerow(['ex:' + short_id, label, '|'.join(synonyms), '|'.join(this_definitions),
+        if label.strip() == '':
+            label = short_id
+
+        writer.writerow(['ge:' + short_id, label, '|'.join(synonyms), '|'.join(this_definitions),
                          '|'.join(this_categories), '|'.join(this_values), '|'.join(this_comments)])
 
     output_file.close()


### PR DESCRIPTION
Change GECKO temporary IDs to numeric IDs. Numeric IDs will stay the same from now on, though the namespace (`http://example.com/`) will change. These IDs are tracked in `src/gecko/index.tsv`.

Genomics England IDs are staying the same.