### PR TITLE
Add more cohorts to mappings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,15 @@ mappings/koges-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | b
 mappings/gcs-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
 	python3 $^ GCS > $@
 
+mappings/genomics-england-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+	python3 $^ GenomicsEngland > $@
+
+mappings/saprin-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+	python3 $^ SAPRIN > $@
+
+mappings/vukuzazi-mapping.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
+	python3 $^ Vukuzazi > $@
+
 # GECKO plus OBO terms
 
 build/mapping/index.owl: mappings/properties.tsv mappings/index.tsv
@@ -235,7 +244,7 @@ build/gecko-full.owl: build/gecko.owl build/mapping/index.owl | build/robot.jar
 
 # Other cohorts -> GECKO mapping
 
-MAPPINGS := build/mapping/koges-gecko.ttl build/mapping/gcs-gecko.ttl
+MAPPINGS := build/mapping/koges-gecko.ttl build/mapping/gcs-gecko.ttl build/mapping/genomics-england-gecko.ttl build/mapping/saprin-gecko.ttl build/mapping/vukuzazi-gecko.ttl
 
 # Cohort terms + GECKO terms from template
 # The GECKO terms are just referenced and do not have structure/annotations

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,13 @@ build/%.html: build/%.owl build/%.tsv | build/robot-validate.jar
 build/mapping/gecko-mapping.xlsx: | build/mapping
 	curl -L -o $@ "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/export?format=xlsx"
 
-MAP_TSV := mappings/index.tsv mappings/properties.tsv mappings/koges-mapping.tsv mappings/gcs-mapping.tsv
+MAP_TSV := mappings/index.tsv \
+mappings/properties.tsv \
+mappings/koges-mapping.tsv \
+mappings/gcs-mapping.tsv \
+mappings/genomics-england-mapping.tsv \
+mappings/saprin-mapping.tsv \
+mappings/vukuzazi-mapping.tsv
 
 mappings/index.tsv: src/xlsx2tsv.py build/mapping/gecko-mapping.xlsx | build/mapping
 	python3 $^ Index > $@

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ build/%-mapping.json: src/json/generate_mapping_json.py build/mapping/%-mapping.
 
 # Top-level cohort data
 
-build/mapping/data.json: src/json/generate_cohort_json.py data/member_cohorts.csv | $(MAPPINGS)
+data/cohort-data.json: src/json/generate_cohort_json.py data/member_cohorts.csv | $(MAPPINGS)
 	python3 $^ $@
 
 
@@ -329,7 +329,7 @@ COHORT_PAGES := build/cohorts/koges.html build/cohorts/gcs.html
 
 cohorts: $(COHORT_PAGES)
 
-$(COHORT_PAGES): src/create_cohort_html.py build/mapping/data.json data/metadata.json src/cohort.html.jinja2 build/cohorts
+$(COHORT_PAGES): src/create_cohort_html.py data/cohort-data.json data/metadata.json src/cohort.html.jinja2 build/cohorts
 	python3 $^
 
 BROWSER := build/index.html build/cineca.json build/koges-mapping.json build/gcs-mapping.json cohorts $(DATA)

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -1,0 +1,122 @@
+[
+  {
+    "cohort_name": "Korean Genome and Epidemiology Study (KoGES)",
+    "countries": [
+      "South Korea",
+      "Vietnam",
+      "Cambodia",
+      "Japan",
+      "China"
+    ],
+    "pi_lead": "Sung Soo Kim",
+    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264",
+    "biosample": {
+      "sample type": [
+        "blood",
+        "urine"
+      ]
+    },
+    "laboratory measures": {
+      "microbiology": [
+        "microbial data"
+      ]
+    },
+    "questionnaire/survey data": {
+      "lifestyle and behaviours": [
+        "alcohol",
+        "nutrition",
+        "sleep",
+        "tobacco"
+      ],
+      "physiological measurements": {
+        "anthropometry": [
+          "height",
+          "weight"
+        ],
+        "circulation and respiration": [
+          "blood pressure",
+          "heart rate"
+        ]
+      },
+      "socio-demographic and economic characteristics": [
+        "education",
+        "family and household structure",
+        "occupation"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Golestan Cohort Study",
+    "countries": [
+      "Iran"
+    ],
+    "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
+    "website": "https://dceg2.cancer.gov/gemshare/",
+    "basic cohort attributes": [
+      "demographic data"
+    ],
+    "biosample": {
+      "sample type": [
+        "blood"
+      ]
+    },
+    "questionnaire/survey data": [
+      "signs and symptoms"
+    ]
+  },
+  {
+    "cohort_name": "Genomics England / 100,000 Genomes Project",
+    "countries": [
+      "England"
+    ],
+    "pi_lead": "Mark Caulfield",
+    "website": "https://www.genomicsengland.co.uk/",
+    "questionnaire/survey data": {
+      "physiological measurements": {
+        "anthropometry": [
+          "height",
+          "weight"
+        ]
+      },
+      "socio-demographic and economic characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "SAPRIN (South African Population Research Infrastructure Network)",
+    "countries": [
+      "South Africa"
+    ],
+    "pi_lead": "Kobus Herbst",
+    "website": "http://saprin.mrc.ac.za/",
+    "questionnaire/survey data": {
+      "socio-demographic and economic characteristics": [
+        "age/birthdate",
+        "biological sex",
+        "education",
+        "ethnicity/race",
+        "family and household structure",
+        "occupation",
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
+    "countries": [
+      "South Africa"
+    ],
+    "pi_lead": "Deenan Pillay",
+    "website": "https://www.ahri.org",
+    "biosample": {
+      "sample type": [
+        "blood",
+        "urine"
+      ]
+    },
+    "questionnaire/survey data": [
+      "signs and symptoms"
+    ]
+  }
+]

--- a/mappings/genomics-england-mapping.tsv
+++ b/mappings/genomics-england-mapping.tsv
@@ -367,8 +367,7 @@ GE:intdays_7	intdays_7
 GE:intdays_8	intdays_8																							
 GE:intdays_9	intdays_9																							
 GE:intmanig	Intended management																							
-GE:lad98	Field Name
- Local authority district in 1998																							
+GE:lad98	Local authority district in 1998																							
 GE:lsoa01	Lower Super Output Area																							
 GE:lsoa11	Lower Super Output Area																							
 GE:mainspef	Main specialty																							
@@ -479,8 +478,7 @@ GE:resgor	Government Office region of residence
 GE:resgor_ons	Government office region of residence (ONS)																							
 GE:resha	Health Authority of residence																							
 GE:resladst	Local authority district of residence																							
-GE:resladst_ons	Field Name
- Local authority district of residence (ONS)																							
+GE:resladst_ons	Local authority district of residence (ONS)																							
 GE:respct	PCT of residence - mapped according to data year																							
 GE:respct06	PCT of residence (2006)																							
 GE:resro	Regional Office of residence																							

--- a/mappings/genomics-england-mapping.tsv
+++ b/mappings/genomics-england-mapping.tsv
@@ -1,0 +1,1256 @@
+ID	Label	Class Type	GECKO Label	Comment																				
+ID	LABEL	CLASS_TYPE	C % SPLIT=|																					
+GE:system_data	System Data																							
+GE:augmented_critical_care_period	Augmented/critical care period																							
+GE:diagnosis	Diagnosis		diseases																					
+GE:patient_data	Patient Data																							
+GE:admissions_period_of_care	Admissions; Period of Care																							
+GE:psychiatric	Psychiatric																							
+GE:maternity	Maternity																							
+GE:geographical	Geographical																							
+GE:episodes_and_spells_period_of_care	Episodes and spells; Period of care																							
+GE:clinical	Clinical																							
+GE:clinical_period_of_care	Clinical; Period of Care																							
+GE:practitioner	Practitioner																							
+GE:organisation	Organisation																							
+GE:discharges_period_of_care	Discharges; Period of Care																							
+GE:healthcare_resource_groups_hrg_data	Healthcare resource groups (HRG) data																							
+GE:patient_pathway	Patient Pathway																							
+GE:socio_economic	Socio-economic																							
+GE:procedure	Procedure																							
+GE:organisation_data	Organisation data																							
+GE:system_data	System data																							
+GE:critical_care_adult_activity_data	Critical care adult activity data																							
+GE:critical_care_period_of_care	Critical care period of care																							
+GE:critical_care_adult_admission_and_discharge_data	Critical care adult admission and discharge data																							
+GE:critical_care_admission_and_discharge_data	Critical care admission and discharge data																							
+GE:critical_care_start_date	Critical care start date																							
+GE:appointments	Appointments																							
+GE:clinical_diagnosis	Clinical Diagnosis																							
+GE:organisation_data	Organisation Data																							
+GE:attendances	Attendances																							
+GE:clinical_diagnoses	Clinical diagnoses																							
+GE:clinical_diagnoses	Clinical Diagnoses																							
+GE:practitioner_data	Practitioner data																							
+GE:clinical_investigations	Clinical Investigations																							
+GE:clinical_treatments	Clinical Treatments																							
+GE:diagnostic_test_dates	Diagnostic Test Dates																							
+GE:ethnic_category	Ethnic Category																							
+GE:imaging_codes	Imaging Codes																							
+GE:referrer_organisation	Referrer Organisation																							
+GE:age_bands	Age Bands																							
+GE:cancer_diagnosis	Cancer diagnosis																							
+GE:ccg	CCG																							
+GE:location	Location																							
+GE:commissioning_organisation	Commissioning Organisation																							
+GE:provider_sha	Provider SHA																							
+GE:provider	Provider																							
+GE:provider_site	Provider Site																							
+GE:indicators	Indicators																							
+GE:administrative	Administrative																							
+GE:scoring	Scoring																							
+GE:hip_replacement_q1	Hip Replacement - Q1																							
+GE:hip_replacement_q2	Hip Replacement - Q2																							
+GE:hip_replacement	Hip Replacement																							
+GE:knee_replacement_q1	Knee Replacement - Q1																							
+GE:knee_replacement_q2	Knee Replacement - Q2																							
+GE:pre_operative_q1	Pre-Operative (Q1)																							
+GE:post_operative_q2	Post-Operative (Q2)																							
+GE:varicose_vein_q1	Varicose Vein - Q1																							
+GE:varicose_vein_q2	Varicose Vein - Q2																							
+GE:participant_id	Patient identifier																							
+GE:epikey	Record identifier																							
+GE:encrypted_hesid	NHS Patient identifier																							
+GE:match_rank	match_rank																							
+GE:susrecid	SUS record ID																							
+GE:acpdisp_1	ACPDISP_N																							
+GE:acpdisp_2	ACPDISP_N																							
+GE:acpdisp_3	ACPDISP_N																							
+GE:acpdisp_4	ACPDISP_N																							
+GE:acpdisp_5	ACPDISP_N																							
+GE:acpdisp_6	ACPDISP_N																							
+GE:acpdisp_7	ACPDISP_N																							
+GE:acpdisp_8	ACPDISP_N																							
+GE:acpdisp_9	ACPDISP_N																							
+GE:acpdqind_1	ACPDQIND_N																							
+GE:acpdqind_2	acpdqind_2																							
+GE:acpdqind_3	acpdqind_3																							
+GE:acpdqind_4	acpdqind_4																							
+GE:acpdqind_5	acpdqind_5																							
+GE:acpdqind_6	acpdqind_6																							
+GE:acpdqind_7	acpdqind_7																							
+GE:acpdqind_8	acpdqind_8																							
+GE:acpdqind_9	acpdqind_9																							
+GE:acpend_1	ACPEND_N																							
+GE:acpend_2	ACPEND_N																							
+GE:acpend_3	ACPEND_N																							
+GE:acpend_4	ACPEND_N																							
+GE:acpend_5	ACPEND_N																							
+GE:acpend_6	ACPEND_N																							
+GE:acpend_7	ACPEND_N																							
+GE:acpend_8	ACPEND_N																							
+GE:acpend_9	ACPEND_N																							
+GE:acploc_1	ACPLOC_N																							
+GE:acploc_2	ACPLOC_N																							
+GE:acploc_3	ACPLOC_N																							
+GE:acploc_4	ACPLOC_N																							
+GE:acploc_5	ACPLOC_N																							
+GE:acploc_6	ACPLOC_N																							
+GE:acploc_7	ACPLOC_N																							
+GE:acploc_8	ACPLOC_N																							
+GE:acploc_9	ACPLOC_N																							
+GE:acpn_1	ACPN_N																							
+GE:acpn_2	ACPN_N																							
+GE:acpn_3	ACPN_N																							
+GE:acpn_4	ACPN_N																							
+GE:acpn_5	ACPN_N																							
+GE:acpn_6	ACPN_N																							
+GE:acpn_7	ACPN_N																							
+GE:acpn_8	ACPN_N																							
+GE:acpn_9	ACPN_N																							
+GE:acpout_1	ACPOUT_N																							
+GE:acpout_2	ACPOUT_N																							
+GE:acpout_3	ACPOUT_N																							
+GE:acpout_4	ACPOUT_N																							
+GE:acpout_5	ACPOUT_N																							
+GE:acpout_6	ACPOUT_N																							
+GE:acpout_7	ACPOUT_N																							
+GE:acpout_8	ACPOUT_N																							
+GE:acpout_9	ACPOUT_N																							
+GE:acpplan_1	ACPPLAN_N																							
+GE:acpplan_2	ACPPLAN_N																							
+GE:acpplan_3	ACPPLAN_N																							
+GE:acpplan_4	ACPPLAN_N																							
+GE:acpplan_5	ACPPLAN_N																							
+GE:acpplan_6	ACPPLAN_N																							
+GE:acpplan_7	ACPPLAN_N																							
+GE:acpplan_8	ACPPLAN_N																							
+GE:acpplan_9	ACPPLAN_N																							
+GE:acpsour_1	ACPSOUR_N																							
+GE:acpsour_2	ACPSOUR_N																							
+GE:acpsour_3	ACPSOUR_N																							
+GE:acpsour_4	ACPSOUR_N																							
+GE:acpsour_5	ACPSOUR_N																							
+GE:acpsour_6	ACPSOUR_N																							
+GE:acpsour_7	ACPSOUR_N																							
+GE:acpsour_8	ACPSOUR_N																							
+GE:acpsour_9	ACPSOUR_N																							
+GE:acpspef_1	Augmented care period specialty function code																							
+GE:acpspef_2	Augmented care period specialty function code																							
+GE:acpspef_3	Augmented care period specialty function code																							
+GE:acpspef_4	Augmented care period specialty function code																							
+GE:acpspef_5	Augmented care period specialty function code																							
+GE:acpspef_6	Augmented care period specialty function code																							
+GE:acpspef_7	Augmented care period specialty function code																							
+GE:acpspef_8	Augmented care period specialty function code																							
+GE:acpspef_9	Augmented care period specialty function code																							
+GE:acpstar_1	Augmented care period start date																							
+GE:acpstar_2	Augmented care period start date																							
+GE:acpstar_3	Augmented care period start date																							
+GE:acpstar_4	Augmented care period start date																							
+GE:acpstar_5	Augmented care period start date																							
+GE:acpstar_6	Augmented care period start date																							
+GE:acpstar_7	Augmented care period start date																							
+GE:acpstar_8	Augmented care period start date																							
+GE:acpstar_9	Augmented care period start date																							
+GE:acscflag	Ambulatory Care Sensitive Condition Flag																							
+GE:activage	Age at activity date																							
+GE:admiage	Age on admission																							
+GE:admidate	Date of admission																							
+GE:admimeth	Method of admission																							
+GE:admincat	ADMINCAT																							
+GE:admincatst	Admin category at start of episode																							
+GE:admisorc	Admission source																							
+GE:admistat	Psychiatric history on admission																							
+GE:aekey	Record identifier																							
+GE:alcdiag	Principal alcohol related diagnosis																							
+GE:alcdiag_4	Principal alcohol related diagnosis																							
+GE:alcfrac	Principal alcohol related fraction																							
+GE:anagest	Gestation period in weeks at first antenatal assessment																							
+GE:anasdate	First antenatal assessment date																							
+GE:antedur	Antenatal days of stay																							
+GE:at_gp_practice	Area Team of GP Practice																							
+GE:at_residence	Area Team of Residence																							
+GE:at_treatment	Area Team of Treatment																							
+GE:bedyear	Bed days within the year																							
+GE:biresus_1	Resuscitation Method																							
+GE:biresus_2	BIRESUS_N																							
+GE:biresus_3	BIRESUS_N																							
+GE:biresus_4	BIRESUS_N																							
+GE:biresus_5	BIRESUS_N																							
+GE:biresus_6	BIRESUS_N																							
+GE:biresus_7	BIRESUS_N																							
+GE:biresus_8	BIRESUS_N																							
+GE:biresus_9	BIRESUS_N																							
+GE:birordr_1	Birth Order																							
+GE:birordr_2	BIRORDR_N																							
+GE:birordr_3	BIRORDR_N																							
+GE:birordr_4	BIRORDR_N																							
+GE:birordr_5	BIRORDR_N																							
+GE:birordr_6	BIRORDR_N																							
+GE:birordr_7	BIRORDR_N																							
+GE:birordr_8	BIRORDR_N																							
+GE:birordr_9	BIRORDR_N																							
+GE:birstat_1	Birth Status																							
+GE:birstat_2	BIRSTAT_N																							
+GE:birstat_3	BIRSTAT_N																							
+GE:birstat_4	BIRSTAT_N																							
+GE:birstat_5	BIRSTAT_N																							
+GE:birstat_6	BIRSTAT_N																							
+GE:birstat_7	BIRSTAT_N																							
+GE:birstat_8	BIRSTAT_N																							
+GE:birstat_9	BIRSTAT_N																							
+GE:birweit_1	Birth Weight																							
+GE:birweit_2	BIRWEIT_N																							
+GE:birweit_3	BIRWEIT_N																							
+GE:birweit_4	BIRWEIT_N																							
+GE:birweit_5	BIRWEIT_N																							
+GE:birweit_6	BIRWEIT_N																							
+GE:birweit_7	BIRWEIT_N																							
+GE:birweit_8	BIRWEIT_N																							
+GE:birweit_9	BIRWEIT_N																							
+GE:cannet	Cancer network																							
+GE:canreg	Cancer registry																							
+GE:carersi	Care Support Indicator																							
+GE:category	Administrative & legal status of patient																							
+GE:cause	Cause Code																							
+GE:ccg_gp_practice	CCG of GP Practice																							
+GE:ccg_residence	CCG of Residence																							
+GE:ccg_responsibility	CCG of Residence																							
+GE:ccg_responsibility_origin	Origin of CCG of Responsibility																							
+GE:ccg_treatment	CCG of Treatment																							
+GE:ccg_treatment_origin	Origin of CCG of Treatment																							
+GE:cdsextdate	CDS extract date																							
+GE:cdsverprotid	CDS protocol identifier																							
+GE:cdsversion	CDS version number																							
+GE:cendur	Duration of care to psychiatric census date																							
+GE:censage	Age at psychiatric census date																							
+GE:censtat	Status of patient included in psychiatric census																							
+GE:cenward	Ward type at psychiatric census date																							
+GE:classpat	Patient classification																							
+GE:consult	Consultant code																							
+GE:cr_gp_practice	Commissioning Region of GP Practice																							
+GE:cr_residence	Commissioning Region of Residence																							
+GE:cr_treatment	Commissioning Region of Treatment																							
+GE:csnum	Commissioning serial number																							
+GE:currward	Current electoral ward																							
+GE:currward_ons	Current electoral ward (ONS)																							
+GE:delchang	Delivery place change reason																							
+GE:delinten	Delivery place (intended)																							
+GE:delmeth_1	Alternative Delivery method (Derived)																							
+GE:delmeth_2	delmeth_2																							
+GE:delmeth_3	delmeth_3																							
+GE:delmeth_4	delmeth_4																							
+GE:delmeth_5	delmeth_5																							
+GE:delmeth_6	delmeth_6																							
+GE:delmeth_7	delmeth_7																							
+GE:delmeth_8	delmeth_8																							
+GE:delmeth_9	delmeth_9																							
+GE:delmeth_d	delmeth_d																							
+GE:delonset	Labour/delivery onset method																							
+GE:delplac_1	Delivery place (actual)																							
+GE:delplac_2	delplac_2																							
+GE:delplac_3	delplac_3																							
+GE:delplac_4	delplac_4																							
+GE:delplac_5	delplac_5																							
+GE:delplac_6	delplac_6																							
+GE:delplac_7	delplac_7																							
+GE:delplac_8	delplac_8																							
+GE:delplac_9	delplac_9																							
+GE:delposan	Anaesthetic given post-labour or delivery																							
+GE:delprean	Anaesthetic given during labour or delivery																							
+GE:delstat_1	Status of person conducting delivery																							
+GE:delstat_2	delstat_2																							
+GE:delstat_3	delstat_3																							
+GE:delstat_4	delstat_4																							
+GE:delstat_5	delstat_5																							
+GE:delstat_6	delstat_6																							
+GE:delstat_7	delstat_7																							
+GE:delstat_8	delstat_8																							
+GE:delstat_9	delstat_9																							
+GE:depdays_1	High-dependency care level																							
+GE:depdays_2	depdays_2																							
+GE:depdays_3	depdays_3																							
+GE:depdays_4	depdays_4																							
+GE:depdays_5	depdays_5																							
+GE:depdays_6	depdays_6																							
+GE:depdays_7	depdays_7																							
+GE:depdays_8	depdays_8																							
+GE:depdays_9	depdays_9																							
+GE:detdur	Duration of detention																							
+GE:detndate	Date detention commenced																							
+GE:diag_01	All Diagnosis codes																							
+GE:diag_02	diag_02																							
+GE:diag_03	diag_03																							
+GE:diag_04	diag_04																							
+GE:diag_05	diag_05																							
+GE:diag_06	diag_06																							
+GE:diag_07	diag_07																							
+GE:diag_08	diag_08																							
+GE:diag_09	diag_09																							
+GE:diag_10	diag_10																							
+GE:diag_11	diag_11																							
+GE:diag_12	diag_12																							
+GE:diag_13	diag_13																							
+GE:diag_14	diag_14																							
+GE:diag_15	diag_15																							
+GE:diag_16	diag_16																							
+GE:diag_17	diag_17																							
+GE:diag_18	diag_18																							
+GE:diag_19	diag_19																							
+GE:diag_20	diag_20																							
+GE:diag_count	Count of diagnoses																							
+GE:disdate	Date of discharge																							
+GE:disdest	Destination on discharge																							
+GE:dismeth	Method of discharge																							
+GE:disreadydate	Discharge ready date																							
+GE:dob	Date of birth - patient																							
+GE:domproc	Trust derived dominant procedure																							
+GE:earldatoff	Earliest reasonable date offered																							
+GE:elecdate	Date of decision to admit																							
+GE:elecdur	Duration of elective wait (submitted)																							
+GE:elecdur_calc	Calculation of Elecdur																							
+GE:endage	Age at end of episode																							
+GE:epidur	Episode duration																							
+GE:epiend	Date episode ended																							
+GE:epiorder	Episode order																							
+GE:epistart	Date episode started																							
+GE:epistat	Episode status																							
+GE:epitype	Episode type																							
+GE:ethnos	Ethnic category																							
+GE:ethraw	Ethnic character (audit version)																							
+GE:fae	Finished Admission Episode																							
+GE:fae_emergency	Finished Admission Episode, emergency classification																							
+GE:fce	Finished Consultant Episode																							
+GE:fde	Finished In-Year Discharge Episode																							
+GE:firstreg	First regular day or night admission																							
+GE:fyear	Financial Year																							
+GE:gestat_1	Length of gestation																							
+GE:gestat_2	gestat_2																							
+GE:gestat_3	gestat_3																							
+GE:gestat_4	gestat_4																							
+GE:gestat_5	gestat_5																							
+GE:gestat_6	gestat_6																							
+GE:gestat_7	gestat_7																							
+GE:gestat_8	gestat_8																							
+GE:gestat_9	gestat_9																							
+GE:gortreat	Government office region of treatment																							
+GE:gpprac	Code of GP practice																							
+GE:gppracha	Health Authority area where patient‚Äö√Ñ√¥s GP is registered																							
+GE:gppracro	Regional Office area where patient‚Äö√Ñ√¥s GP was registered																							
+GE:gpprpct	Primary Care Trust area where patient‚Äö√Ñ√¥s GP was registered																							
+GE:gpprstha	Strategic Health Authority area where patient‚Äö√Ñ√¥s GP was registered																							
+GE:hatreat	Ordnance Survey grid reference																							
+GE:hneoind	Healthly Neonate Indicator																							
+GE:hrglate35	Trust derived HRG value v3.5																							
+GE:hrgnhs	Trust derived HRG value																							
+GE:hrgnhsvn	Version No. of Trust derived HRG																							
+GE:imd04	IMD Index of Multiple Deprivation																							
+GE:imd04_decile	IMD Decile Group																							
+GE:imd04c	IMD Crime Domain																							
+GE:imd04ed	IMD Education Training and Skills Domain																							
+GE:imd04em	IMD Employment Deprivation Domain																							
+GE:imd04hd	IMD Health and Disability Domain																							
+GE:imd04hs	IMD Barriers to Housing and Service Domain																							
+GE:imd04i	IMD Income Domain																							
+GE:imd04ia	IMD Income affecting Adults Domain																							
+GE:imd04ic	IMD Income affecting Children Domain																							
+GE:imd04le	IMD Living Environment Domain																							
+GE:imd04rk	IMD Overall Rank																							
+GE:intdays_1	Intensive care level days																							
+GE:intdays_2	intdays_2																							
+GE:intdays_3	intdays_3																							
+GE:intdays_4	intdays_4																							
+GE:intdays_5	intdays_5																							
+GE:intdays_6	intdays_6																							
+GE:intdays_7	intdays_7																							
+GE:intdays_8	intdays_8																							
+GE:intdays_9	intdays_9																							
+GE:intmanig	Intended management																							
+GE:lad98	Field Name
+ Local authority district in 1998																							
+GE:lsoa01	Lower Super Output Area																							
+GE:lsoa11	Lower Super Output Area																							
+GE:mainspef	Main specialty																							
+GE:marstat	Marital status (psychiatric)																							
+GE:matage	Mother‚Äö√Ñ√¥s age at delivery																							
+GE:maternity_episode_type	Episode Type - Maternity																							
+GE:msoa01	Middle Super Output Area, 2001																							
+GE:msoa11	Middle Super Output Area, 2011																							
+GE:neocare	Neonatal level of care																							
+GE:neodur	Age of baby in days																							
+GE:newnhsno_check	NHS Number valid flag																							
+GE:nhsnoind	NHS number status indicator																							
+GE:numacp	Number of augmented care periods within episode																							
+GE:numbaby	Number of babies		pregnancy history																					
+GE:numpreg	Number of previous pregnancies		pregnancy history																					
+GE:numtailb	Number of baby tails																							
+GE:opcs43	opcs43																							
+GE:opdate_01	Date of procedure		surgical interventions																					
+GE:opdate_02	opdate_02		surgical interventions																					
+GE:opdate_03	opdate_03		surgical interventions																					
+GE:opdate_04	opdate_04		surgical interventions																					
+GE:opdate_05	opdate_05		surgical interventions																					
+GE:opdate_06	opdate_06		surgical interventions																					
+GE:opdate_07	opdate_07		surgical interventions																					
+GE:opdate_08	opdate_08		surgical interventions																					
+GE:opdate_09	opdate_09		surgical interventions																					
+GE:opdate_10	opdate_10		surgical interventions																					
+GE:opdate_11	opdate_11		surgical interventions																					
+GE:opdate_12	opdate_12		surgical interventions																					
+GE:opdate_13	opdate_13		surgical interventions																					
+GE:opdate_14	opdate_14		surgical interventions																					
+GE:opdate_15	opdate_15		surgical interventions																					
+GE:opdate_16	opdate_16		surgical interventions																					
+GE:opdate_17	opdate_17		surgical interventions																					
+GE:opdate_18	opdate_18		surgical interventions																					
+GE:opdate_19	opdate_19		surgical interventions																					
+GE:opdate_20	opdate_20		surgical interventions																					
+GE:opdate_21	opdate_21		surgical interventions																					
+GE:opdate_22	opdate_22		surgical interventions																					
+GE:opdate_23	opdate_23		surgical interventions																					
+GE:opdate_24	opdate_24		surgical interventions																					
+GE:operstat	Operation status code		surgical interventions																					
+GE:opertn_01	Operative procedure		surgical interventions																					
+GE:opertn_02	opertn_02																							
+GE:opertn_03	opertn_03																							
+GE:opertn_04	opertn_04																							
+GE:opertn_05	opertn_05																							
+GE:opertn_06	opertn_06																							
+GE:opertn_07	opertn_07																							
+GE:opertn_08	opertn_08																							
+GE:opertn_09	opertn_09																							
+GE:opertn_10	opertn_10																							
+GE:opertn_11	opertn_11																							
+GE:opertn_12	opertn_12																							
+GE:opertn_13	opertn_13																							
+GE:opertn_14	opertn_14																							
+GE:opertn_15	opertn_15																							
+GE:opertn_16	opertn_16																							
+GE:opertn_17	opertn_17																							
+GE:opertn_18	opertn_18																							
+GE:opertn_19	opertn_19																							
+GE:opertn_20	opertn_20																							
+GE:opertn_21	opertn_21																							
+GE:opertn_22	opertn_22																							
+GE:opertn_23	opertn_23																							
+GE:opertn_24	opertn_24																							
+GE:opertn_count	Count of procedures																							
+GE:orgpppid	Organisation code (patient pathway ID issuer)																							
+GE:orgsup_1	Number of organ systems supported																							
+GE:orgsup_2	orgsup_2																							
+GE:orgsup_3	orgsup_3																							
+GE:orgsup_4	orgsup_4																							
+GE:orgsup_5	orgsup_5																							
+GE:orgsup_6	orgsup_6																							
+GE:orgsup_7	orgsup_7																							
+GE:orgsup_8	orgsup_8																							
+GE:orgsup_9	orgsup_9																							
+GE:partyear	Year and month of HES dataset																							
+GE:pcfound	Postcode Found																							
+GE:pcgcode	Primary care group																							
+GE:pcgorig	Origin of primary care group																							
+GE:pcon	Westminster parliamentary constituency																							
+GE:pcon_ons	Westminster parliamentary constituency (ONS)																							
+GE:pctcode	PCT of responsibility dependent on the data year																							
+GE:pctcode06	PCT of responsibility (2006)																							
+GE:pctnhs	Primary care trust																							
+GE:pctorig	Origin of primary care trust of responsibility																							
+GE:pctorig06	Origin of PCT of responsibility (2006)																							
+GE:pcttreat	Primary Care Trust area of main provider																							
+GE:posopdur	Post-operative duration																							
+GE:postdist	Postcode district																							
+GE:postdur	Postnatal stay																							
+GE:preopdur	Pre-operative duration																							
+GE:primercp	primercp																							
+GE:procode	Provider Code																							
+GE:procode3	Provider code (3 character)																							
+GE:procode5	Provider code (5 character)																							
+GE:procodet	Provider code of treatment																							
+GE:protype	Provider type																							
+GE:purcode	Commissioner code																							
+GE:purro	Commissioner‚Äö√Ñ√¥s Regional Office																							
+GE:purstha	Commissioner‚Äö√Ñ√¥s Strategic Health Authority																							
+GE:purval	Commissioner code status																							
+GE:referorg	Referring organisation code																							
+GE:rescty	County of residence																							
+GE:rescty_ons	County of residence (ONS)																							
+GE:resgor	Government Office region of residence																							
+GE:resgor_ons	Government office region of residence (ONS)																							
+GE:resha	Health Authority of residence																							
+GE:resladst	Local authority district of residence																							
+GE:resladst_ons	Field Name
+ Local authority district of residence (ONS)																							
+GE:respct	PCT of residence - mapped according to data year																							
+GE:respct06	PCT of residence (2006)																							
+GE:resro	Regional Office of residence																							
+GE:resstha	SHA of residence																							
+GE:resstha06	SHA of residence (2006)																							
+GE:rotreat	Regional Office of treatment																							
+GE:rttperend	RTT period end date																							
+GE:rttperstart	REFERRAL TO TREATMENT- RTT period start date																							
+GE:rttperstat	RTT period status																							
+GE:rururb_ind	Rural/Urban Indicator																							
+GE:sender	CDS sender identity																							
+GE:sex	Sex of patient																							
+GE:sexbaby_1	Sex of baby																							
+GE:sexbaby_2	sexbaby_2																							
+GE:sexbaby_3	sexbaby_3																							
+GE:sexbaby_4	sexbaby_4																							
+GE:sexbaby_5	sexbaby_5																							
+GE:sexbaby_6	sexbaby_6																							
+GE:sexbaby_7	sexbaby_7																							
+GE:sexbaby_8	sexbaby_8																							
+GE:sexbaby_9	sexbaby_9																							
+GE:sitetret	Site code of treatment																							
+GE:spelbgin	Beginning of spell indicator																							
+GE:speldur	Duration of spell																							
+GE:spelend	End of spell indicator																							
+GE:startage	Age at start of episode																							
+GE:startage_calc	Age at start of episode - babies decimalised																							
+GE:sthatret	SHA area of treatment																							
+GE:subdate	Submission date																							
+GE:suscorehrg	SUS generated Core Spell HRG																							
+GE:sushrg	SUS generated HRG																							
+GE:sushrgvers	SUS generated HRG version number																							
+GE:suslddate	SUS loaded staging date																							
+GE:susspellid	SUS generated spell identifier																							
+GE:tretspef	Treatment specialty																							
+GE:vind	V code indicator																							
+GE:waitdays	Duration of wait (referral to treatment period)																							
+GE:waitlist	Method of Admission - Waiting List																							
+GE:ward91	Electoral ward in 1991																							
+GE:ward98	Electoral ward in 1998																							
+GE:wardstrt	Ward type at start of episode																							
+GE:well_baby_ind	Well baby flag																							
+GE:acardsupdays	acardsupdays																							
+GE:aressupdays	aressupdays																							
+GE:bcardsupdays	bcardsupdays																							
+GE:bestmatch	bestmatch																							
+GE:bressupdays	bressupdays																							
+GE:ccadmisorc	ccadmisorc																							
+GE:ccadmitype	ccadmitype																							
+GE:ccapcrel	ccapcrel																							
+GE:ccdisdate	ccdisdate																							
+GE:ccdisdest	ccdisdest																							
+GE:ccdisloc	ccdisloc																							
+GE:ccdisrdydate	ccdisrdydate																							
+GE:ccdisrdytime	ccdisrdytime																							
+GE:ccdisstat	ccdisstat																							
+GE:ccdistime	ccdistime																							
+GE:cclev2days	cclev2days																							
+GE:cclev3days	cclev3days																							
+GE:ccsorcloc	ccsorcloc																							
+GE:ccstartdate	ccstartdate																							
+GE:ccstarttime	ccstarttime																							
+GE:ccunitfun	ccunitfun																							
+GE:dermsupdays	dermsupdays																							
+GE:gisupdays	gisupdays																							
+GE:liversupdays	liversupdays																							
+GE:neurosupdays	neurosupdays																							
+GE:orgsupmax	orgsupmax																							
+GE:rensupdays	rensupdays																							
+GE:unitbedconfig	unitbedconfig																							
+GE:attendkey	Record identifier																							
+GE:apptage	Age on day of appointment																							
+GE:apptage_calc	Age on arrival - babies decimalised																							
+GE:apptdate	Appointment date																							
+GE:atentype	Attendance type																							
+GE:attended	Attended or did not attend																							
+GE:attendkey_flag	Attendence Key Flag																							
+GE:dnadate	Last DNA or patient cancelled date																							
+GE:ethrawl	Ethnic category (audit version)																							
+GE:firstatt	First attendance																							
+GE:locclass	Location Class																							
+GE:loctype	Location Tyoe																							
+GE:nodiags	Number of Diagnoses																							
+GE:noprocs	Number of Procedures																							
+GE:oacode01	Census Output Area, 2011																							
+GE:oacode11	Census Output Area, 2011																							
+GE:oacode6	Census output area, 2001 (6 character ward identifier)																							
+GE:outcome	Outcome of attendance																							
+GE:pctorig_his	Origin of primary care trust of responsibility dependent on the data year																							
+GE:pgpprac	Pseudonymised code of GP practice																							
+GE:primerecp	primerecp																							
+GE:priority	Priority type																							
+GE:referrer	Referrer code																							
+GE:reggmp	Code of patient‚Äö√Ñ√¥s registered or referring general medical practitioner																							
+GE:reqdate	Referral request received date																							
+GE:respct02	PCT of residence (2002)																							
+GE:resstha02	SHA of residence (2002)																							
+GE:servtype	Service type requested																							
+GE:stafftyp	Medical staff type seeing patient																							
+GE:wait_ind	Waiting calculation indicator																							
+GE:waiting	Days waiting																							
+GE:aearrivalmode	Arrival mode																							
+GE:aeattend_exc_planned	Attendances excluding planned																							
+GE:aeattendcat	Attendance category																							
+GE:aeattenddisp	Attendance disposal																							
+GE:aedepttype	Department type																							
+GE:aeincloctype	Incident location type																							
+GE:aekey_flag	AEKEY flag																							
+GE:aepatgroup	Patient group																							
+GE:aerefsource	Source of referral for A&E																							
+GE:appdate	Net applicable date																							
+GE:arrivalage	Age on arrival																							
+GE:arrivalage_calc	Age on arrival - babies decimalised																							
+GE:arrivaldate	Arrival date																							
+GE:arrivaltime	Arrival time																							
+GE:concldur	Duration to conclusion																							
+GE:concltime	Conclusion time																							
+GE:depdur	Duration to departure																							
+GE:deptime	Departure time																							
+GE:diag2_01	A&E diagnosis: 2 character																							
+GE:diag2_02	diag2_02																							
+GE:diag2_03	diag2_03																							
+GE:diag2_04	diag2_04																							
+GE:diag2_05	diag2_05																							
+GE:diag2_06	diag2_06																							
+GE:diag2_07	diag2_07																							
+GE:diag2_08	diag2_08																							
+GE:diag2_09	diag2_09																							
+GE:diag2_10	diag2_10																							
+GE:diag2_11	diag2_11																							
+GE:diag2_12	diag2_12																							
+GE:diaga_01	A&E diagnosis - anatomical area																							
+GE:diaga_02	diaga_02																							
+GE:diaga_03	diaga_03																							
+GE:diaga_04	diaga_04																							
+GE:diaga_05	diaga_05																							
+GE:diaga_06	diaga_06																							
+GE:diaga_07	diaga_07																							
+GE:diaga_08	diaga_08																							
+GE:diaga_09	diaga_09																							
+GE:diaga_10	diaga_10																							
+GE:diaga_11	diaga_11																							
+GE:diaga_12	diaga_12																							
+GE:diags_01	A&E diagnosis - anatomical side																							
+GE:diags_02	diags_02																							
+GE:diags_03	diags_03																							
+GE:diags_04	diags_04																							
+GE:diags_05	diags_05																							
+GE:diags_06	diags_06																							
+GE:diags_07	diags_07																							
+GE:diags_08	diags_08																							
+GE:diags_09	diags_09																							
+GE:diags_10	diags_10																							
+GE:diags_11	diags_11																							
+GE:diags_12	diags_12																							
+GE:diagscheme	Diagnosis Scheme in Use																							
+GE:initdur	Duration to assessment																							
+GE:inittime	Initial assessment time																							
+GE:invest_01	A&E investigation																							
+GE:invest_02	invest_02																							
+GE:invest_03	invest_03																							
+GE:invest_04	invest_04																							
+GE:invest_05	invest_05																							
+GE:invest_06	invest_06																							
+GE:invest_07	invest_07																							
+GE:invest_08	invest_08																							
+GE:invest_09	invest_09																							
+GE:invest_10	invest_10																							
+GE:invest_11	invest_11																							
+GE:invest_12	invest_12																							
+GE:invest2_01	A&E Investigation: 2 character																							
+GE:invest2_02	invest2_02																							
+GE:invest2_03	invest2_03																							
+GE:invest2_04	invest2_04																							
+GE:invest2_05	invest2_05																							
+GE:invest2_06	invest2_06																							
+GE:invest2_07	invest2_07																							
+GE:invest2_08	invest2_08																							
+GE:invest2_09	invest2_09																							
+GE:invest2_10	invest2_10																							
+GE:invest2_11	invest2_11																							
+GE:invest2_12	invest2_12																							
+GE:noinvests	Number of Investigations																							
+GE:notreats	Number of Treatments																							
+GE:pctcode_his	PCT of responsibility dependent on the data year																							
+GE:pctcode02	PCT of responsibility (2002)																							
+GE:pctorig02	Origin of PCT of responsibility (2002)																							
+GE:perend	Reporting period end date																							
+GE:respct_his	PCT of residence - mapped according to data year																							
+GE:resstha_his	resstha_his																							
+GE:sushrginfo	SUS generated HRG for information																							
+GE:sushrgverinfo	SUS generated HRG version number																							
+GE:treat_01	A&E treatment																							
+GE:treat_02	treat_02																							
+GE:treat_03	treat_03																							
+GE:treat_04	treat_04																							
+GE:treat_05	treat_05																							
+GE:treat_06	treat_06																							
+GE:treat_07	treat_07																							
+GE:treat_08	treat_08																							
+GE:treat_09	treat_09																							
+GE:treat_10	treat_10																							
+GE:treat_11	treat_11																							
+GE:treat_12	treat_12																							
+GE:treat2_01	A&E Treatment: 2 character																							
+GE:treat2_02	treat2_02																							
+GE:treat2_03	treat2_03																							
+GE:treat2_04	treat2_04																							
+GE:treat2_05	treat2_05																							
+GE:treat2_06	treat2_06																							
+GE:treat2_07	treat2_07																							
+GE:treat2_08	treat2_08																							
+GE:treat2_09	treat2_09																							
+GE:treat2_10	treat2_10																							
+GE:treat2_11	treat2_11																							
+GE:treat2_12	treat2_12																							
+GE:tretdur	Duration to treatment																							
+GE:trettime	Time seen for treatment																							
+GE:submissiondataid	Record Identifier																							
+GE:did_date1	Diagnostic Test Request Date																							
+GE:did_date2	Diagnostic Test Request Received Date																							
+GE:did_date3	Diagnostic Test Date																							
+GE:did_date3_month	Month of Test																							
+GE:did_date3_year	Year of Test																							
+GE:did_date4	Service Report Issue Date																							
+GE:did_ethcat	Ethnic Category Code																							
+GE:did_ethcat_grp	Ethnic Category Group																							
+GE:did_gender_code	Gender Code																							
+GE:did_nhsnum_stat	NHS Number Status																							
+GE:did_nicip_code	Imaging Code (NICIP)																							
+GE:did_patsource_code	Patient Source Setting																							
+GE:did_refer_orgcode	Referrer Organisation code																							
+GE:did_snomedct_code	did_snomedct_code																							
+GE:ic_age10	Age Band 10 years																							
+GE:ic_age17_60	ic_age17_60																							
+GE:ic_age17_64	ic_age17_64																							
+GE:ic_age5	Age Band 5 years																							
+GE:ic_age50_74	ic_age50_74																							
+GE:ic_agechild	ic_agechild																							
+GE:ic_cancer_desc	Early cancer diagnosis																							
+GE:ic_ccgcode	CCG Code																							
+GE:ic_ccgname	CCG Name																							
+GE:ic_date1_to_date2	Test Request to Test Request Received																							
+GE:ic_date1_to_date3	Test Request to Test																							
+GE:ic_date1_to_date4	Test Request to Service (Test) Report Issue																							
+GE:ic_date2_to_date3	Test Request Received to Test																							
+GE:ic_date2_to_date4	Test Request Received to Service (test) Report Issue																							
+GE:ic_date3_to_date4	Test to Service (Test) Report Issue																							
+GE:ic_ethcat_desc	Ethnic Category Description																							
+GE:ic_fetal_desc	Fetal																							
+GE:ic_fetal_id	Fetal ID																							
+GE:ic_gender_desc	Gender Description		gender																					
+GE:ic_lsoa	Location - LSOA																							
+GE:ic_modality_desc	Modality																							
+GE:ic_modality_id	Modality ID																							
+GE:ic_morphology_id	Morphology ID																							
+GE:ic_morph_desc	Morphology																							
+GE:ic_msoa	Location - MSOA																							
+GE:ic_nhsnum_stat_desc	NHS Number Status Description																							
+GE:ic_nicip_desc	Imaging Code (NICIP) Description																							
+GE:ic_patsource_desc	Patient Source Setting Description																							
+GE:ic_pctcode	Commissioning Organisation Code																							
+GE:ic_pctname	Commissioning Organisation Name																							
+GE:ic_prov_orgcode	Organisation Code																							
+GE:ic_prov_shacode	Provider SHA Code																							
+GE:ic_prov_shaname	Provider SHA Name																							
+GE:ic_provname	Provider Name																							
+GE:ic_refer_orgname	Referrer																							
+GE:ic_reftype_desc	Referrer type																							
+GE:ic_region_desc	Region																							
+GE:ic_region_id	Region ID																							
+GE:ic_sitecode	Provider Site Code																							
+GE:ic_sitename	Provider Site Name																							
+GE:ic_snomedct_desc	Imaging Code (SNOMED)																							
+GE:ic_sub_cancer_desc	Sub Early cancer diagnosis																							
+GE:ic_sub_modality_desc	Sub Modality																							
+GE:ic_sub_modality_id	Sub Modality ID																							
+GE:ic_sub_region_desc	Sub Region																							
+GE:ic_sub_region_id	Sub Region ID																							
+GE:ic_sub_sys_desc	Sub System																							
+GE:ic_sub_sys_id	Sub System ID																							
+GE:ic_sub_syscomp_desc	Sub-System Component																							
+GE:ic_sub_syscomp_id	Sub-System Component ID																							
+GE:ic_submit_orgcode	Organisation Code																							
+GE:ic_submit_orgname	Organisation Name																							
+GE:ic_system_desc	System																							
+GE:ic_system_id	System ID																							
+GE:hes_dids_version	hes_dids_version																							
+GE:arthritis	Arthritis Indicator																							
+GE:cancer	Cancer Indicator																							
+GE:circulation	Circulation																							
+GE:complete	Complete																							
+GE:depression	Depression																							
+GE:diabetes	Diabetes																							
+GE:episode_match_rank	EPISODE MATCH RANK																							
+GE:episode_matched	episode_matched																							
+GE:eq5d_health_scale_expected_final_model3	EQ5D HEALTH SCALE EXPECTED (MODEL1)																							
+GE:eq5d_index_change	eq5d_index_change																							
+GE:eq5d_index_expected_final_model3	EQ5D HEALTH SCALE EXPECTED (FINAL MODEL1)																							
+GE:eq5d_scale_change	EQ5D INDEX CHANGE																							
+GE:gender	Gender																							
+GE:heart_disease	Heart Disease Indicator																							
+GE:hesid_matched	HESID Matched																							
+GE:hesid_rank	Hesid Rank																							
+GE:high_bp	High Blood Pressiure Indicator																							
+GE:hr_q1_dressing	Q1-HR6																							
+GE:hr_q1_limping	Q1-HR9																							
+GE:hr_q1_night_pain	Q1-HR3																							
+GE:hr_q1_pain	Q1-HR1																							
+GE:hr_q1_score	hr_q1_score																							
+GE:hr_q1_score_complete	hr_q1_score_complete																							
+GE:hr_q1_shopping	Q1-HR7																							
+GE:hr_q1_stairs	Q1-HR10																							
+GE:hr_q1_standing	Q1-HR11																							
+GE:hr_q1_sudden_pain	Q1-HR2																							
+GE:hr_q1_transport	Q1-HR5																							
+GE:hr_q1_walking	Q1-HR8																							
+GE:hr_q1_washing	Q1-HR4																							
+GE:hr_q1_work	Q1-HR12																							
+GE:hr_q2_dressing	Q2-HR6																							
+GE:hr_q2_limping	Q2-HR9																							
+GE:hr_q2_night_pain	Q2-HR3																							
+GE:hr_q2_pain	Q2-HR1																							
+GE:hr_q2_score	hr_q2_score																							
+GE:hr_q2_score_complete	hr_q2_score_complete																							
+GE:hr_q2_shopping	Q2-HR7																							
+GE:hr_q2_stairs	Q2-HR10																							
+GE:hr_q2_standing	Q2-HR11																							
+GE:hr_q2_sudden_pain	Q2-HR2																							
+GE:hr_q2_transport	Q2-HR5																							
+GE:hr_q2_walking	Q2-HR8																							
+GE:hr_q2_washing	Q2-HR4																							
+GE:hr_q2_work	Q2-HR12																							
+GE:hr_score_expected_final_model3	hr_score_expected_final_model3																							
+GE:kidney_disease	Kidney Disease																							
+GE:kr_q1_confidence	Q1 - KR10																							
+GE:kr_q1_kneeling	Q1 - KR8																							
+GE:kr_q1_limping	Q1-KR7																							
+GE:kr_q1_night_pain	Q1-KR2																							
+GE:kr_q1_pain	Q1-KR1																							
+GE:kr_q1_score	Q1-KR5																							
+GE:kr_q1_score_complete	kr_q1_score_complete																							
+GE:kr_q1_shopping	Q1-KR11																							
+GE:kr_q1_stairs	Q1-KR12																							
+GE:kr_q1_standing	Q1-KR6																							
+GE:kr_q1_transport	Q1-KR4																							
+GE:kr_q1_walking	Q1-KR5																							
+GE:kr_q1_washing	Q1-KR3																							
+GE:kr_q1_work	Q1-KR9																							
+GE:kr_q2_confidence	Q2-KR10																							
+GE:kr_q2_kneeling	Q2-KR8																							
+GE:kr_q2_limping	Q2-KR7																							
+GE:kr_q2_night_pain	Q2-KR2																							
+GE:kr_q2_pain	Q2-KR1																							
+GE:kr_q2_score	kr_q2_score																							
+GE:kr_q2_score_complete	kr_q2_score_complete																							
+GE:kr_q2_shopping	Q2-KR11																							
+GE:kr_q2_stairs	kr_q2_stairs																							
+GE:kr_q2_standing	Q2-KR6																							
+GE:kr_q2_transport	Q2-KR4																							
+GE:kr_q2_walking	Q2-KR5																							
+GE:kr_q2_washing	Q2-KR3																							
+GE:kr_q2_work	Q2-KR9																							
+GE:kr_score_expected_final_model3	kr_score_expected_final_model3																							
+GE:liver_disease	Liver Disease																							
+GE:lung_disease	Lung Disease																							
+GE:modified_date	modified_date																							
+GE:nervous_system	nervous_system																							
+GE:patient_death	patient_death																							
+GE:proc_revision_flag	Procedure Revision Flag																							
+GE:proms_proc_code	Proms Procedure Code																							
+GE:proms_proc_group	proms_proc_group																							
+GE:proms_serial_no	proms_serial_no																							
+GE:q1_activity	PreOp3																							
+GE:q1_anxiety	PreOp5																							
+GE:q1_assisted	q1_assisted																							
+GE:q1_assisted_by	q1_assisted_by																							
+GE:q1_complete	q1_complete																							
+GE:q1_completed_date	q1_completed_date																							
+GE:q1_disability	q1_disability																							
+GE:q1_discomfort	PO4																							
+GE:q1_eq5d_health_scale	q1_eq5d_health_scale																							
+GE:q1_eq5d_index	q1_eq5d_index																							
+GE:q1_eq5d_profile	q1_eq5d_profile																							
+GE:q1_eq5d_profile_complete	q1_eq5d_profile_complete																							
+GE:q1_eq5d_scale_complete	q1_eq5d_scale_complete																							
+GE:q1_form_version	q1_form_version																							
+GE:q1_general_health	q1_general_health																							
+GE:q1_language	q1_language																							
+GE:q1_living_arrangements	q1_living_arrangements																							
+GE:q1_mobility	q1_mobility																							
+GE:q1_previous_surgery	q1_previous_surgery		pregnancy history																					
+GE:q1_procode	q1_procode																							
+GE:q1_received_date	q1_received_date																							
+GE:q1_scan_date	q1_scan_date																							
+GE:q1_self_care	q1_self_care																							
+GE:q1_symptom_period	q1_symptom_period																							
+GE:q2_activity	PostOp3																							
+GE:q2_allergy	q2_allergy																							
+GE:q2_anxiety	PostOp5																							
+GE:q2_assisted	q2_assisted																							
+GE:q2_assisted_by	q2_assisted_by																							
+GE:q2_bleeding	q2_bleeding																							
+GE:q2_complete	q2_complete																							
+GE:q2_completed_date	q2_completed_date																							
+GE:q2_disability	q2_disability																							
+GE:q2_discomfort	PostOp4																							
+GE:q2_eq5d_health_scale	q2_eq5d_health_scale																							
+GE:q2_eq5d_index	q2_eq5d_index																							
+GE:q2_eq5d_profile	q2_eq5d_profile																							
+GE:q2_eq5d_profile_complete	q2_eq5d_profile_complete																							
+GE:q2_eq5d_scale_complete	q2_eq5d_scale_complete																							
+GE:q2_form_version	q2_form_version																							
+GE:q2_further_surgery	q2_further_surgery		pregnancy history																					
+GE:q2_general_health	q2_general_health																							
+GE:q2_language	q2_language																							
+GE:q2_living_arrangements	q2_living_arrangements																							
+GE:q2_mobility	q2_mobility																							
+GE:q2_readmitted	q2_readmitted																							
+GE:q2_received_date	q2_received_date																							
+GE:q2_satisfaction	q2_satisfaction																							
+GE:q2_scan_date	q2_scan_date																							
+GE:q2_self_care	q2_self_care																							
+GE:q2_success	q2_success																							
+GE:q2_surgery_date	q2_surgery_date																							
+GE:q2_urine	q2_urine																							
+GE:q2_wound	q2_wound																							
+GE:score_change	score_change																							
+GE:status	status																							
+GE:status_date	status_date																							
+GE:stroke	stroke																							
+GE:vv_q1_clothing	Q1-VV4																							
+GE:vv_q1_concern	Q1-VV3																							
+GE:vv_q1_left_back_count	Q1-VV7																							
+GE:vv_q1_left_discolour	Q1-VV11																							
+GE:vv_q1_left_front_count	Q1-VV7																							
+GE:vv_q1_left_itch	Q1-VV10																							
+GE:vv_q1_left_pain_days	Q1-VV8																							
+GE:vv_q1_left_rash	Q1-VV12																							
+GE:vv_q1_left_support	Q1-VV9																							
+GE:vv_q1_left_ulcer	Q1-VV13																							
+GE:vv_q1_leisure	Q1-VV6																							
+GE:vv_q1_max_score	vv_q1_max_score																							
+GE:vv_q1_painkiller_days	Q1-VV1																							
+GE:vv_q1_right_back_count	Q1-VV7																							
+GE:vv_q1_right_discolour	Q1-VV11																							
+GE:vv_q1_right_front_count	Q1-VV7																							
+GE:vv_q1_right_itch	Q1-VV10																							
+GE:vv_q1_right_pain_days	Q1-VV9																							
+GE:vv_q1_right_rash	Q1-VV12																							
+GE:vv_q1_right_support	Q1-VV																							
+GE:vv_q1_right_ulcer	Q1-VV13																							
+GE:vv_q1_score	vv_q1_score																							
+GE:vv_q1_score_complete	vv_q1_score_complete																							
+GE:vv_q1_swelling	Q1-VV2																							
+GE:vv_q1_total_score	vv_q1_total_score																							
+GE:vv_q1_work	Q1-VV5																							
+GE:vv_q2_clothing	Q2-VV4																							
+GE:vv_q2_concern	Q2-VV3																							
+GE:vv_q2_left_back_count	Q2-VV7																							
+GE:vv_q2_left_discolour	Q2-VV11																							
+GE:vv_q2_left_front_count	Q2-VV7																							
+GE:vv_q2_left_itch	Q2-VV10																							
+GE:vv_q2_left_pain_days	Q2-VV8																							
+GE:vv_q2_left_rash	Q2-VV12																							
+GE:vv_q2_left_support	Q2-VV9																							
+GE:vv_q2_left_ulcer	Q2-VV13																							
+GE:vv_q2_left_visible	Q2-VV2																							
+GE:vv_q2_leisure	Q2-VV6																							
+GE:vv_q2_max_score	vv_q2_max_score																							
+GE:vv_q2_painkiller_days	Q2-VV1																							
+GE:vv_q2_right_back_count	Q2-VV7																							
+GE:vv_q2_right_discolour	Q2-VV11																							
+GE:vv_q2_right_front_count	Q2-VV7																							
+GE:vv_q2_right_itch	Q2-VV10																							
+GE:vv_q2_right_pain_days	Q2-VV9																							
+GE:vv_q2_right_rash	Q2-VV12																							
+GE:vv_q2_right_support	Q2-VV																							
+GE:vv_q2_right_ulcer	Q2-VV13																							
+GE:vv_q2_right_visible	Q2-VV2																							
+GE:vv_q2_score	vv_q2_score																							
+GE:vv_q2_score_complete	vv_q2_score_complete																							
+GE:vv_q2_swelling	Q1-VV2																							
+GE:vv_q2_total_score	vv_q2_total_score																							
+GE:vv_q2_work	Q1-VV5																							
+GE:vv_score_expected_final_model3	VV Score Final Predicted (Model 3)																							
+GE:mhd_mhmds_person_id	mhd_mhmds_person_id																							
+GE:mhd_mhmds_spell_id	mhd_mhmds_spell_id																							
+GE:ic_annual_id	ic_annual_id																							
+GE:ic_inactive_timestamp	ic_inactive_timestamp																							
+GE:ic_interim_ccg_code	ic_interim_ccg_code																							
+GE:ic_rec_ccg	ic_rec_ccg																							
+GE:ic_rec_endrp_aot_flag	ic_rec_endrp_aot_flag																							
+GE:ic_rec_endrp_cluster_flag	ic_rec_endrp_cluster_flag																							
+GE:ic_rec_endrp_cluster_type	ic_rec_endrp_cluster_type																							
+GE:ic_rec_endrp_cpa_epi_12_months	ic_rec_endrp_cpa_epi_12_months																							
+GE:ic_rec_endrp_cpa_flag	ic_rec_endrp_cpa_flag																							
+GE:ic_rec_endrp_cpa_review_within_12mnths	ic_rec_endrp_cpa_review_within_12mnths																							
+GE:ic_rec_endrp_eit_flag	ic_rec_endrp_eit_flag																							
+GE:ic_rec_endrp_employment_status	ic_rec_endrp_employment_status																							
+GE:ic_rec_endrp_honos_assessment_within_12mnths	ic_rec_endrp_honos_assessment_within_12mnths																							
+GE:ic_rec_endrp_hospital_spell_flag	ic_rec_endrp_hospital_spell_flag																							
+GE:ic_rec_endrp_mha_flag	ic_rec_endrp_mha_flag																							
+GE:ic_rec_endrp_pdiag_flag	ic_rec_endrp_pdiag_flag																							
+GE:ic_rec_endrp_recall_flag	ic_rec_endrp_recall_flag																							
+GE:ic_rec_endrp_sct_flag	ic_rec_endrp_sct_flag																							
+GE:ic_rec_endrp_settled_accommodation_indicator	ic_rec_endrp_settled_accommodation_indicator																							
+GE:ic_rec_ethnicity	ic_rec_ethnicity																							
+GE:ic_rec_rp_admission	ic_rec_rp_admission																							
+GE:ic_rec_rp_admission_formal	ic_rec_rp_admission_formal																							
+GE:ic_rec_rp_awol	ic_rec_rp_awol																							
+GE:ic_rec_rp_commissioners	ic_rec_rp_commissioners																							
+GE:ic_rec_rp_contacts	ic_rec_rp_contacts																							
+GE:ic_rec_rp_contacts_att	ic_rec_rp_contacts_att																							
+GE:ic_rec_rp_dayatt_contacts	ic_rec_rp_dayatt_contacts																							
+GE:ic_rec_rp_dayatt_contacts_att	ic_rec_rp_dayatt_contacts_att																							
+GE:ic_rec_rp_ddisc_days	ic_rec_rp_ddisc_days																							
+GE:ic_rec_rp_disch_net_followup	ic_rec_rp_disch_net_followup																							
+GE:ic_rec_rp_discharges_gross	ic_rec_rp_discharges_gross																							
+GE:ic_rec_rp_discharges_net	ic_rec_rp_discharges_net																							
+GE:ic_rec_rp_readmissions	ic_rec_rp_readmissions																							
+GE:ic_rec_rp_wrdst_days_cleansed	ic_rec_rp_wrdst_days_cleansed																							
+GE:ic_rec_rp_wrdst_days_gross	ic_rec_rp_wrdst_days_gross																							
+GE:ic_rec_rp_wrdst_days_net	ic_rec_rp_wrdst_days_net																							
+GE:ic_source_period_id	ic_source_period_id																							
+GE:ic_spell_rp_days	ic_spell_rp_days																							
+GE:mhd_age	mhd_age																							
+GE:mhd_ccg_of_gp_practice	mhd_ccg_of_gp_practice																							
+GE:mhd_ccg_of_residence	mhd_ccg_of_residence																							
+GE:mhd_code_of_commissioner	mhd_code_of_commissioner																							
+GE:mhd_code_of_gp_practice	mhd_code_of_gp_practice																							
+GE:mhd_county	mhd_county																							
+GE:mhd_crisisplancreat_date	mhd_crisisplancreat_date																							
+GE:mhd_crisisplanupdate_date	mhd_crisisplanupdate_date																							
+GE:mhd_electoral_ward_of_usual_address	mhd_electoral_ward_of_usual_address																							
+GE:mhd_emerpsych_date	mhd_emerpsych_date																							
+GE:mhd_end_date_mhcs	mhd_end_date_mhcs																							
+GE:mhd_ethnicity	mhd_ethnicity																							
+GE:mhd_gender	mhd_gender																							
+GE:mhd_health_care_spell_end_reason	mhd_health_care_spell_end_reason																							
+GE:mhd_lad_ua	mhd_lad_ua																							
+GE:mhd_manpsych_date	mhd_manpsych_date																							
+GE:mhd_marital_status	mhd_marital_status																							
+GE:mhd_pct_of_gp_practice	mhd_pct_of_gp_practice																							
+GE:mhd_pct_of_residence	mhd_pct_of_residence																							
+GE:mhd_postcode_district	mhd_postcode_district																							
+GE:mhd_propsych_date	mhd_propsych_date																							
+GE:mhd_provider_org_code	mhd_provider_org_code																							
+GE:mhd_psychpresc_date	mhd_psychpresc_date																							
+GE:mhd_psychtreat_start_date	mhd_psychtreat_start_date																							
+GE:mhd_start_date_mhcs	mhd_start_date_mhcs																							
+GE:mhd_valid_nhs_number_flag	mhd_valid_nhs_number_flag																							
+GE:mhd_valid_postcode_flag	mhd_valid_postcode_flag																							
+GE:mhd_year_of_first_known_psychiatric_care	mhd_year_of_first_known_psychiatric_care																							
+GE:reportingperiod_enddate	reportingperiod_enddate																							
+GE:reportingperiod_startdate	reportingperiod_startdate																							
+GE:ic_eve_primarydiagnosis	ic_eve_primarydiagnosis																							
+GE:ic_eve_secondarydiagnosis	ic_eve_secondarydiagnosis																							
+GE:mhd_abusequestion_indicator	mhd_abusequestion_indicator																							
+GE:mhd_accomodation_status	mhd_accomodation_status																							
+GE:mhd_assessment	mhd_assessment																							
+GE:mhd_attended_indicator	mhd_attended_indicator																							
+GE:mhd_carecluster_superclass_code	mhd_carecluster_superclass_code																							
+GE:mhd_carecoordinator_flag	mhd_carecoordinator_flag																							
+GE:mhd_clusteringtool_assessment_reason	mhd_clusteringtool_assessment_reason																							
+GE:mhd_consultmedium	mhd_consultmedium																							
+GE:mhd_contact_location_code	mhd_contact_location_code																							
+GE:mhd_contact_subject	mhd_contact_subject																							
+GE:mhd_duration	mhd_duration																							
+GE:mhd_employment_status	mhd_employment_status																							
+GE:mhd_event_id	mhd_event_id																							
+GE:mhd_eventdate	mhd_eventdate																							
+GE:mhd_eventtype	mhd_eventtype																							
+GE:mhd_honos_flag	mhd_honos_flag																							
+GE:mhd_honos_honosrating1_score	mhd_honos_honosrating1_score																							
+GE:mhd_honos_honosrating10_score	mhd_honos_honosrating10_score																							
+GE:mhd_honos_honosrating11_score	mhd_honos_honosrating11_score																							
+GE:mhd_honos_honosrating12_score	mhd_honos_honosrating12_score																							
+GE:mhd_honos_honosrating2_score	mhd_honos_honosrating2_score																							
+GE:mhd_honos_honosrating3_score	mhd_honos_honosrating3_score																							
+GE:mhd_honos_honosrating4_score	mhd_honos_honosrating4_score																							
+GE:mhd_honos_honosrating5_score	mhd_honos_honosrating5_score																							
+GE:mhd_honos_honosrating6_score	mhd_honos_honosrating6_score																							
+GE:mhd_honos_honosrating7_score	mhd_honos_honosrating7_score																							
+GE:mhd_honos_honosrating8_score	mhd_honos_honosrating8_score																							
+GE:mhd_honos_honosrating8_type	mhd_honos_honosrating8_type																							
+GE:mhd_honos_honosrating9_score	mhd_honos_honosrating9_score																							
+GE:mhd_honos_secure_flag	mhd_honos_secure_flag																							
+GE:mhd_honos65_flag	mhd_honos65_flag																							
+GE:mhd_honos65_rating1_score	mhd_honos65_rating1_score																							
+GE:mhd_honos65_rating10_score	mhd_honos65_rating10_score																							
+GE:mhd_honos65_rating11_score	mhd_honos65_rating11_score																							
+GE:mhd_honos65_rating12_score	mhd_honos65_rating12_score																							
+GE:mhd_honos65_rating2_score	mhd_honos65_rating2_score																							
+GE:mhd_honos65_rating3_score	mhd_honos65_rating3_score																							
+GE:mhd_honos65_rating4_score	mhd_honos65_rating4_score																							
+GE:mhd_honos65_rating5_score	mhd_honos65_rating5_score																							
+GE:mhd_honos65_rating6_score	mhd_honos65_rating6_score																							
+GE:mhd_honos65_rating7_score	mhd_honos65_rating7_score																							
+GE:mhd_honos65_rating8_score	mhd_honos65_rating8_score																							
+GE:mhd_honos65_rating8_type	mhd_honos65_rating8_type																							
+GE:mhd_honos65_rating9_score	mhd_honos65_rating9_score																							
+GE:mhd_honosca_flag	mhd_honosca_flag																							
+GE:mhd_honoscarating1_score	mhd_honoscarating1_score																							
+GE:mhd_honoscarating10_score	mhd_honoscarating10_score																							
+GE:mhd_honoscarating11_score	mhd_honoscarating11_score																							
+GE:mhd_honoscarating12_score	mhd_honoscarating12_score																							
+GE:mhd_honoscarating13_score	mhd_honoscarating13_score																							
+GE:mhd_honoscarating14_score	mhd_honoscarating14_score																							
+GE:mhd_honoscarating15_score	mhd_honoscarating15_score																							
+GE:mhd_honoscarating2_score	mhd_honoscarating2_score																							
+GE:mhd_honoscarating3_score	mhd_honoscarating3_score																							
+GE:mhd_honoscarating4_score	mhd_honoscarating4_score																							
+GE:mhd_honoscarating5_score	mhd_honoscarating5_score																							
+GE:mhd_honoscarating6_score	mhd_honoscarating6_score																							
+GE:mhd_honoscarating7_score	mhd_honoscarating7_score																							
+GE:mhd_honoscarating8_score	mhd_honoscarating8_score																							
+GE:mhd_honoscarating9_score	mhd_honoscarating9_score																							
+GE:mhd_honossecureratinga_score	mhd_honossecureratinga_score																							
+GE:mhd_honossecureratingb_score	mhd_honossecureratingb_score																							
+GE:mhd_honossecureratingc_score	mhd_honossecureratingc_score																							
+GE:mhd_honossecureratingd_score	mhd_honossecureratingd_score																							
+GE:mhd_honossecureratinge_score	mhd_honossecureratinge_score																							
+GE:mhd_honossecureratingf_score	mhd_honossecureratingf_score																							
+GE:mhd_honossecureratingg_score	mhd_honossecureratingg_score																							
+GE:mhd_jobrole	mhd_jobrole																							
+GE:mhd_mainspecialty	mhd_mainspecialty																							
+GE:mhd_mhc_team_type	mhd_mhc_team_type																							
+GE:mhd_mhct_flag	mhd_mhct_flag																							
+GE:mhd_mhct_honosrating1_score	mhd_mhct_honosrating1_score																							
+GE:mhd_mhct_honosrating10_score	mhd_mhct_honosrating10_score																							
+GE:mhd_mhct_honosrating11_score	mhd_mhct_honosrating11_score																							
+GE:mhd_mhct_honosrating12_score	mhd_mhct_honosrating12_score																							
+GE:mhd_mhct_honosrating2_score	mhd_mhct_honosrating2_score																							
+GE:mhd_mhct_honosrating3_score	mhd_mhct_honosrating3_score																							
+GE:mhd_mhct_honosrating4_score	mhd_mhct_honosrating4_score																							
+GE:mhd_mhct_honosrating5_score	mhd_mhct_honosrating5_score																							
+GE:mhd_mhct_honosrating6_score	mhd_mhct_honosrating6_score																							
+GE:mhd_mhct_honosrating7_score	mhd_mhct_honosrating7_score																							
+GE:mhd_mhct_honosrating8_score	mhd_mhct_honosrating8_score																							
+GE:mhd_mhct_honosrating8_type	mhd_mhct_honosrating8_type																							
+GE:mhd_mhct_honosrating9_score	mhd_mhct_honosrating9_score																							
+GE:mhd_nhs_occupcode	mhd_nhs_occupcode																							
+GE:mhd_pbr_cluster	mhd_pbr_cluster																							
+GE:mhd_phq9_q1_score	mhd_phq9_q1_score																							
+GE:mhd_phq9_q2_score	mhd_phq9_q2_score																							
+GE:mhd_phq9_q3_score	mhd_phq9_q3_score																							
+GE:mhd_phq9_q4_score	mhd_phq9_q4_score																							
+GE:mhd_phq9_q5_score	mhd_phq9_q5_score																							
+GE:mhd_phq9_q6_score	mhd_phq9_q6_score																							
+GE:mhd_phq9_q7_score	mhd_phq9_q7_score																							
+GE:mhd_phq9_q8_score	mhd_phq9_q8_score																							
+GE:mhd_phq9_q9_score	mhd_phq9_q9_score																							
+GE:mhd_phq9_total_score	mhd_phq9_total_score																							
+GE:mhd_primarydiagnosis	mhd_primarydiagnosis																							
+GE:mhd_sacrating13_score	mhd_sacrating13_score																							
+GE:mhd_sacratinga_score	mhd_sacratinga_score																							
+GE:mhd_sacratingb_score	mhd_sacratingb_score																							
+GE:mhd_sacratingc_score	mhd_sacratingc_score																							
+GE:mhd_sacratingd_score	mhd_sacratingd_score																							
+GE:mhd_sacratinge_score	mhd_sacratinge_score																							
+GE:mhd_secondarydiagnosis	mhd_secondarydiagnosis																							
+GE:mhd_settled_accommodation_indicator	mhd_settled_accommodation_indicator																							
+GE:mhd_treat	mhd_treat																							
+GE:mhd_weekly_hours_worked	mhd_weekly_hours_worked																							
+GE:ic_epi_rp_days	ic_epi_rp_days																							
+GE:ic_episode_epi_days	ic_episode_epi_days																							
+GE:mhd_admimet	mhd_admimet																							
+GE:mhd_commissioner_code	mhd_commissioner_code																							
+GE:mhd_delayed_dischend_date	mhd_delayed_dischend_date																							
+GE:mhd_delayed_dischreason	mhd_delayed_dischreason																							
+GE:mhd_delayed_dischstart_date	mhd_delayed_dischstart_date																							
+GE:mhd_dischdate	mhd_dischdate																							
+GE:mhd_dischmet	mhd_dischmet																							
+GE:mhd_dischreason	mhd_dischreason																							
+GE:mhd_endreason	mhd_endreason																							
+GE:mhd_endtime	mhd_endtime																							
+GE:mhd_epiend_date	mhd_epiend_date																							
+GE:mhd_episode_id	mhd_episode_id																							
+GE:mhd_epistart_date	mhd_epistart_date																							
+GE:mhd_epitype	mhd_epitype																							
+GE:mhd_expirydate	mhd_expirydate																							
+GE:mhd_expirytime	mhd_expirytime																							
+GE:mhd_int_clincare_intensity_code	mhd_int_clincare_intensity_code																							
+GE:mhd_intended_agegroup	mhd_intended_agegroup																							
+GE:mhd_mencat07	mhd_mencat07																							
+GE:mhd_referral_request_status_date	mhd_referral_request_status_date																							
+GE:mhd_refrec_date	mhd_refrec_date																							
+GE:mhd_sex_code	mhd_sex_code																							
+GE:mhd_source_of_referral	mhd_source_of_referral																							
+GE:mhd_starttime	mhd_starttime																							
+GE:mhd_status_of_service_request	mhd_status_of_service_request																							
+GE:mhd_teamtype	mhd_teamtype																							
+GE:mhd_wardsec_level	mhd_wardsec_level																							
+GE:event_type	event_type																							
+GE:event_date	event_date																							
+GE:supplied_gender	supplied_gender																							
+GE:supplied_date_of_birth	supplied_date_of_birth																							
+GE:latest_gender	latest_gender																							
+GE:latest_date_of_birth	latest_date_of_birth																							
+GE:date_of_death	date_of_death																							
+GE:gender_of_deceased	gender_of_deceased																							
+GE:date_of_birth	date_of_birth																							
+GE:date_of_registration	date_of_registration																							
+GE:icd9_underlying_cause	icd9_underlying_cause																							
+GE:icd9_multiple_cause_code_1	icd9_multiple_cause_code_1																							
+GE:icd9_multiple_cause_code_2	icd9_multiple_cause_code_2																							
+GE:icd9_multiple_cause_code_3	icd9_multiple_cause_code_3																							
+GE:icd9_multiple_cause_code_4	icd9_multiple_cause_code_4																							
+GE:icd9_multiple_cause_code_5	icd9_multiple_cause_code_5																							
+GE:icd9_multiple_cause_code_6	icd9_multiple_cause_code_6																							
+GE:icd9_multiple_cause_code_7	icd9_multiple_cause_code_7																							
+GE:icd9_multiple_cause_code_8	icd9_multiple_cause_code_8																							
+GE:icd9_multiple_cause_code_9	icd9_multiple_cause_code_9																							
+GE:icd9_multiple_cause_code_10	icd9_multiple_cause_code_10																							
+GE:icd9_multiple_cause_code_11	icd9_multiple_cause_code_11																							
+GE:icd9_multiple_cause_code_12	icd9_multiple_cause_code_12																							
+GE:icd9_multiple_cause_code_13	icd9_multiple_cause_code_13																							
+GE:icd9_multiple_cause_code_14	icd9_multiple_cause_code_14																							
+GE:icd9_multiple_cause_code_15	icd9_multiple_cause_code_15																							
+GE:icd10_underlying_cause	icd10_underlying_cause																							
+GE:icd10_multiple_cause_code_1	icd10_multiple_cause_code_1																							
+GE:icd10_multiple_cause_code_2	icd10_multiple_cause_code_2																							
+GE:icd10_multiple_cause_code_3	icd10_multiple_cause_code_3																							
+GE:icd10_multiple_cause_code_4	icd10_multiple_cause_code_4																							
+GE:icd10_multiple_cause_code_5	icd10_multiple_cause_code_5																							
+GE:icd10_multiple_cause_code_6	icd10_multiple_cause_code_6																							
+GE:icd10_multiple_cause_code_7	icd10_multiple_cause_code_7																							
+GE:icd10_multiple_cause_code_8	icd10_multiple_cause_code_8																							
+GE:icd10_multiple_cause_code_9	icd10_multiple_cause_code_9																							
+GE:icd10_multiple_cause_code_10	icd10_multiple_cause_code_10																							
+GE:icd10_multiple_cause_code_11	icd10_multiple_cause_code_11																							
+GE:icd10_multiple_cause_code_12	icd10_multiple_cause_code_12																							
+GE:icd10_multiple_cause_code_13	icd10_multiple_cause_code_13																							
+GE:icd10_multiple_cause_code_14	icd10_multiple_cause_code_14																							
+GE:icd10_multiple_cause_code_15	icd10_multiple_cause_code_15																							
+GE:patient_pseudo_id	patient_pseudo_id																							
+GE:tumour_pseudo_id	tumour_pseudo_id																							
+GE:nhs_number_status	nhs_number_status																							
+GE:gender_current_clean	gender_current_clean																							
+GE:consultant_speciality_code	consultant_speciality_code																							
+GE:primary_diagnosis	primary_diagnosis																							
+GE:morphology_clean	morphology_clean																							
+GE:stage_at_start	stage_at_start																							
+GE:regimen_number	regimen_number																							
+GE:programme_number	programme_number																							
+GE:intent_of_treatment	intent_of_treatment																							
+GE:analysis_group	analysis_group																							
+GE:benchmark_group	benchmark_group																							
+GE:height_at_start_of_regimen	height_at_start_of_regimen		height																					
+GE:weight_at_start_of_regimen	weight_at_start_of_regimen		weight																					
+GE:perf_stat_start_of_reg_clean	perf_stat_start_of_reg_clean																							
+GE:comorbidity_adjustment	comorbidity_adjustment																							
+GE:date_decision_to_treat	date_decision_to_treat																							
+GE:start_date_of_regimen	start_date_of_regimen																							
+GE:clinical_trial	clinical_trial																							
+GE:chemo_radiation	chemo_radiation																							
+GE:number_of_cycles_planned	number_of_cycles_planned																							
+GE:cycle_number	cycle_number																							
+GE:start_date_of_cycle	start_date_of_cycle																							
+GE:weight_at_start_of_cycle	weight_at_start_of_cycle		weight																					
+GE:perf_stat_start_of_cycle_clean	perf_stat_start_of_cycle_clean																							
+GE:opcs_procurement_code	opcs_procurement_code																							
+GE:drug_group	drug_group																							
+GE:actual_dose_per_administration	actual_dose_per_administration																							
+GE:administration_route	administration_route																							
+GE:administration_date	administration_date																							
+GE:opcs_delivery_code	opcs_delivery_code																							
+GE:date_of_final_treatment	date_of_final_treatment																							
+GE:regimen_mod_dose_reduction	regimen_mod_dose_reduction																							
+GE:regimen_mod_time_delay	regimen_mod_time_delay																							
+GE:regimen_mod_stopped_early	regimen_mod_stopped_early																							
+GE:regimen_outcome_summary	regimen_outcome_summary																							

--- a/mappings/index.tsv
+++ b/mappings/index.tsv
@@ -278,10 +278,10 @@ GECKO:1000039		blood homocysteine level value		equivalent	blood measurement valu
 GECKO:1000040		X-ray imaging result			physiological measurements		X-Ray Imaging																				
 GECKO:1000041		brain MRI result			physiological measurements	brain																					
 GECKO:1000042		physical performance testing result			physiological measurements		Physical Performance Testing																				
-GECKO:1000043		diagnosis of dementia			mental and behaviour disorders	dementia																					
-GECKO:1000044		diagnosis of depression			mental and behaviour disorders	Depressivity				mental health																	
-GECKO:1000045		diagnosis of vascular dementia			diagnosis of dementia	vascular dementia																					
-GECKO:1000046		diagnosis of Alzheimer's disease			diagnosis of dementia	DOID:10652																					
+GECKO:1000043		diagnosis of dementia			mental and behaviour disorders				dementia																		
+GECKO:1000044		diagnosis of depression			mental and behaviour disorders				Depressivity	mental health																	
+GECKO:1000045		diagnosis of vascular dementia			diagnosis of dementia				vascular dementia																		
+GECKO:1000046		diagnosis of Alzheimer's disease			diagnosis of dementia				DOID:10652																		
 GECKO:1000047		diagnosis of arthritis	yes/no		diseases				arthritis																		
 GECKO:1000048		diagnosis of nose disease	yes/no		diseases				nose disease																		
 GECKO:1000049		diagnosis of auditory system disease	yes/no		diseases				auditory system disease																		
@@ -441,7 +441,7 @@ GECKO:1000134		history of medication for gastrointestinal disease			disease(s) t
 GECKO:1000135		opiate use history			recreational drug use history																						
 GECKO:1000136		oral health history			clinical history																						
 GECKO:1000137		recreational drug use history			clinical history|lifestyle and behaviours																						
-GECKO:1000138		diagnosis of HIV			diagnosis of viral infection																						
+GECKO:1000138		diagnosis of HIV			diagnosis of viral infection				human immunodeficiency virus infectious disease																		
 GECKO:1000139		diagnosis of viral infection			diseases																						
 GECKO:1000140		occurrence of high cholesterol			signs and symptoms					symptom or diagnosis?																	
 GECKO:1000141		occurrence of cough			signs and symptoms																						
@@ -449,3 +449,4 @@ GECKO:1000142		occurrence of fever			signs and symptoms
 GECKO:1000143		occurrence of weight loss			signs and symptoms																						
 GECKO:1000144		occurrence of night sweats			signs and symptoms																						
 GECKO:1000145		history of medication for tuberculosis			disease(s) treated with medication																						
+DOID:526	human immunodeficiency virus infectious disease	human immunodeficiency virus infectious disease			disease																						

--- a/mappings/index.tsv
+++ b/mappings/index.tsv
@@ -441,3 +441,11 @@ GECKO:1000134		history of medication for gastrointestinal disease			disease(s) t
 GECKO:1000135		opiate use history			recreational drug use history																						
 GECKO:1000136		oral health history			clinical history																						
 GECKO:1000137		recreational drug use history			clinical history|lifestyle and behaviours																						
+GECKO:1000138		diagnosis of HIV			diagnosis of viral infection																						
+GECKO:1000139		diagnosis of viral infection			diseases																						
+GECKO:1000140		occurrence of high cholesterol			signs and symptoms					symptom or diagnosis?																	
+GECKO:1000141		occurrence of cough			signs and symptoms																						
+GECKO:1000142		occurrence of fever			signs and symptoms																						
+GECKO:1000143		occurrence of weight loss			signs and symptoms																						
+GECKO:1000144		occurrence of night sweats			signs and symptoms																						
+GECKO:1000145		history of medication for tuberculosis			disease(s) treated with medication																						

--- a/mappings/saprin-mapping.tsv
+++ b/mappings/saprin-mapping.tsv
@@ -1,1007 +1,146 @@
-Field ID	Field Label	Definition	Class Type	GECKO Label	Comment																			
-ID	LABEL		CLASS_TYPE	C % SPLIT=|																				
-SAPRIN:Base_Entities	Base Entities	The core entities on which longitudinal data will be collected. Each entity has a dated start and end event																						
-SAPRIN:Location	Location	A place to which geo-coordinates can be assigned																						
-SAPRIN:Type_Location	Type (Location)																							
-SAPRIN:Area	Area	Village or other higher level spatial grouping of locations																						
-SAPRIN:Coordinate	Coordinate	Latitude and longitude on the WGS84 coordinate system																						
-SAPRIN:Household	Household	A household resident at a location within the boundary of the surveillance area. A household is defined as a social group of one or more individual members. Resident household members share the same dwelling as the household, non-resident household members are individuals who do not share the same dwelling as the household, but who eat from the same pot when they are present in the household‚Äôs dwelling.		residence																				
-SAPRIN:Identifier_Household	Identifier (Household)	A unique household identifier which the household retains irrespective of its current residence		residence																				
-SAPRIN:Individual	Individual	Household members, where a resident is a member of a household who normally lives (i.e. intends to sleep the majority of the time) at the same dwelling as the household; and a non-resident is a member of a household who does not normally live at the same dwelling as the household but is nevertheless considered a member of the household.		family and household structure																				
-SAPRIN:Identifier_Individual	Identifier (Individual)	A globally unique identifier used internally to uniquely identify the individual																						
-SAPRIN:External_identifier_Individual	External identifier (Individual)	An identifier used on data collection instruments to uniquely identify the individual, but is removed together with other personally identifiable information when data is made available for analysis																						
-SAPRIN:Surname	Surname	Family or last name																						
-SAPRIN:Alternative_surname	Alternative surname	An alternative surname (formerly) used by the individual, e.g. maiden name																						
-SAPRIN:First_name_1	First name 1	The first given name of the individual																						
-SAPRIN:First_name_2	First name 2	The second/alternative given name of the individual																						
-SAPRIN:Civilian_ID_number	Civilian ID number	The 13-digit South African civilian identity number																						
-SAPRIN:Citizenship	Citizenship	The country of which the individual is a citizen		residence																				
-SAPRIN:Nationality	Nationality	The country of origin of the individual (the country of which the person is/was a citizen by birth)		ethnicity/race																				
-SAPRIN:Sex	Sex	Male (1), female(2) or unknown(0)		biological sex																				
-SAPRIN:Birth_Individual	Birth (Individual)	The Birth event of this individual or the DeliveryEvent resulting in the birth of this individual if the individual enters surveillance through birth																						
-SAPRIN:EndEvent_Individual	EndEvent (Individual)	The death event of this individual or the Observation at which this individual was last observed																						
-SAPRIN:MotherId	MotherId	The unique identifier of the mother of the individual, if the mother is enumerated in the surveillance																						
-SAPRIN:FatherId	FatherId	The unique identifier of the father of the individual, if the father is enumerated in the surveillance																						
-SAPRIN:MotherSurname	MotherSurname	The surname of the mother of the individual																						
-SAPRIN:MotherFirstName	MotherFirstName	The first name/s of the mother																						
-SAPRIN:FatherSurname	FatherSurname	The surname of the father of the individual																						
-SAPRIN:FatherFirstName	FatherFirstName	The first name/s of the father																						
-SAPRIN:Events	Events	Demographic events that delineate episodes of observation during longitudinal surveillance																						
-SAPRIN:Migration	Migration	A change in location of usual residence		residence	Maybe?																			
-SAPRIN:Date_Migration	Date (Migration)	Date of migration		residence	Maybe?																			
-SAPRIN:Type_Migration	Type (Migration)			residence	Maybe?																			
-SAPRIN:Direction	Direction			residence	Maybe?																			
-SAPRIN:Origin	Origin	Origin of the migration (location)		residence	Maybe?																			
-SAPRIN:Destination	Destination	Destination of the migration (location)		residence	Maybe?																			
-SAPRIN:Unit	Unit	Individual or household																						
-SAPRIN:Birth	Birth	The birth event of an individual																						
-SAPRIN:Date_Birth	Date (Birth)	Date of birth		age/birthdate																				
-SAPRIN:Birth_weight	Birth weight	Birth weight as obtained from the Road to Health card in grams																						
-SAPRIN:BirthCertificate	BirthCertificate	Whether the birth certificate was observed																						
-SAPRIN:DateRegistered	DateRegistered	The date on which the birth was registered, or null if the birth hasn‚Äôt been registered yet																						
-SAPRIN:PregnancyOutcome	PregnancyOutcome	The end event of a pregnancy		pregnancy history																				
-SAPRIN:Date_PregnancyOutcome	Date (PregnancyOutcome)	Date of birth		pregnancy history																				
-SAPRIN:Type_PregnancyOutcome	Type (PregnancyOutcome)	Types i-ii is only applicable if the pregnancy end prior to the 28th week of pregnancy, types iii-v is applicable only on or after the 28th week of pregnancy		pregnancy history																				
-SAPRIN:Place_PregnancyOutcome	Place (PregnancyOutcome)			pregnancy history																				
-SAPRIN:BirthAttendant	BirthAttendant			pregnancy history																				
-SAPRIN:LiveBirths	LiveBirths	The number of babies born alive resulting from this delivery		pregnancy history																				
-SAPRIN:Stillborn	Stillborn	The number of still born babies resulting from this delivery		pregnancy history																				
-SAPRIN:Death	Death	The death of an individual																						
-SAPRIN:Date_Death	Date (Death)	The date of the death																						
-SAPRIN:Place_Death	Place (Death)																							
-SAPRIN:DeathCertificate	DeathCertificate	Observed																						
-SAPRIN:Verbal_autopsy	Verbal autopsy	WHO standard verbal autopsy questionnaire items. SAPRIN will adopt the worldwide standardised World Health Organisation (WHO) Verbal Autopsy questionnaires to determine the cause of deaths reported in the surveillance population. The latest version of the WHO Verbal Autopsy Questionnaire is 2016, edited and cognitively tested to facilitate the use of publicly available analytical software for assigning the cause of death.																						
-SAPRIN:Enumeration	Enumeration	The initial event at enumeration of an entity. Can only be used during the base census of the demographic surveillance, or when a new area is added to the surveillance																						
-SAPRIN:Date_Enumeration	Date (Enumeration)	Date of enumeration																						
-SAPRIN:Membership_Events	Membership Events	A change in household membership																						
-SAPRIN:Date_Membership_Events	Date (Membership Events)	The date of the change																						
-SAPRIN:Type_Membership_Events	Type (Membership Events)																							
-SAPRIN:Household_Headship	Household Headship	A change in the head of the household		family and household structure																				
-SAPRIN:Date_Household_Headship	Date (Household Headship)	The date of the change																						
-SAPRIN:Type_Household_Headship	Type (Household Headship)																							
-SAPRIN:UnionEvent	UnionEvent	A change in the union (conjugal relationship) between two individuals																						
-SAPRIN:Date_UnionEvent	Date (UnionEvent)	The date of the event																						
-SAPRIN:Type_UnionEvent	Type (UnionEvent)																							
-SAPRIN:Observation	Observation	A surveillance visit at a location																						
-SAPRIN:Date_Observation	Date (Observation)	Visit date																						
-SAPRIN:Location_Observation	Location (Observation)	Location where the visit took place																						
-SAPRIN:DataCollector	DataCollector	The person responsible for data collection during the visit																						
-SAPRIN:Respondent	Respondent	The primary respondent at the visit																						
-SAPRIN:Episodes	Episodes	Used to record associations longitudinally between base entities. Episodes are always started and ended through events.																						
-SAPRIN:Residence	Residence	An episode during which an individual is resident (sleeping most of the time there) at a particular location that falls within the surveillance area. An individual can only be resident at one location at a time, i.e. residency episodes cannot overlap																						
-SAPRIN:Individual_Residence	Individual (Residence)	The individual identifier																						
-SAPRIN:Location_Residence	Location (Residence)	The location identifier																						
-SAPRIN:StartEvent_Residence	StartEvent (Residence)	The event that started the episode, can only be Enumeration, Birth, Migration (Direction: In)																						
-SAPRIN:EndEvent_Residence	EndEvent (Residence)	The event that terminated the episode, can only be Death, Migration (Direction: Out) and Observation (in which the implication is that the individual is last known to be resident)																						
-SAPRIN:HouseholdResidence	HouseholdResidence	An episode during which a household is resident at a particular location that falls within the surveillance area. A household can only be resident at one location at a time, i.e. residency episodes cannot overlap																						
-SAPRIN:Household_HouseholdResidence	Household (HouseholdResidence)	The household identifier																						
-SAPRIN:Location_HouseholdResidence	Location (HouseholdResidence)	The location identifier																						
-SAPRIN:External_identifier_HouseholdResidence	External identifier (HouseholdResidence)	The identifier associated with the household during this residence																						
-SAPRIN:StartEvent_HouseholdResidence	StartEvent (HouseholdResidence)	The event that started the episode, can only be Enumeration, Household formation, Migration (Direction: In)																						
-SAPRIN:EndEvent_HouseholdResidence	EndEvent (HouseholdResidence)	The event that terminated the episode, can only be Household dissolution, Migration (Direction: Out) and Observation (in which the implication is that the household is last known to be resident)																						
-SAPRIN:Membership_Episodes	Membership Episodes	An episode during which an individual is a member of a household. An individual must be a member of at least one household to be under surveillance. An individual can be a member of more than one household at a time (membership episodes may overlap). In the case of multiple memberships, the designated household of an individual will be the household the individual is co-resident with, ranked according to the closeness of the members relationship to the household head (self, spouse, child, grandchild, parent, sibling, other relationship)																						
-SAPRIN:Individual_Membership_Episodes	Individual (Membership Episodes)	The individual identifier																						
-SAPRIN:Household_Membership_Episodes	Household (Membership Episodes)	The household identifier																						
-SAPRIN:StartEvent_Membership_Episodes	StartEvent (Membership Episodes)	The event that started the episode, can only be Enumeration, Birth or Membership start																						
-SAPRIN:EndEvent_Membership_Episodes	EndEvent (Membership Episodes)	The event that ended the episode, can only be Death, Membership end or Observation (implying that the membership is current)																						
-SAPRIN:Household_Head_Relationship	Household Head Relationship	Household head relationships are linked to a household membership and record the relationship between the individual and the head of the associated household. If the head of household change, all current household members start a new household head relationship episode																						
-SAPRIN:Membership_Household_Head_Relationship	Membership (Household Head Relationship)	The household membership episode associated with this household head relationship																						
-SAPRIN:Relationship	Relationship	The relationship between the individual member (to whom the membership belongs) and the current household head of the household																						
-SAPRIN:StartEvent_Household_Head_Relationship	StartEvent (Household Head Relationship)	The event that started the episode. Can only be Enumeration, Birth, Membership start, or Household Headship start																						
-SAPRIN:EndEvent_Household_Head_Relationship	EndEvent (Household Head Relationship)	The event that ended the episode. Can only be Death, Membership end, Household Headship end or Observation																						
-SAPRIN:Union	Union	The episode during which two persons are in an informal or formal conjugal relationship. For a conjugal relationship to exist the following factors should be considered:
- i. Shelter. Do the partners live under the same roof?
- ii. Sexual and personal conduct. Do the partners have sexual relations; do they maintain an attitude of fidelity to each other; do they eat their meals together?
- iii. Services. Do they share household responsibilities?
- iv. Social. Do they participate together in social activities; does their society recognise them as a couple?
- v. Support. Do they support each other financially?
- vi. Children. Do they have children together?																						
-SAPRIN:Individual1	Individual1	The individual identifier of one of the parties to the union. By convention this will be the female in a heterosexual union.																						
-SAPRIN:Individual2	Individual2	The individual identifier of the second party to the union.																						
-SAPRIN:StartEvent_Union	StartEvent (Union)	The start of the union. Can only be Enumeration or Union start																						
-SAPRIN:MarriageDate	MarriageDate	The date on which the union has been formalised as a marriage																						
-SAPRIN:EndEvent_Union	EndEvent (Union)	The end of the union. Can only be Union ‚Äì partner died, Union ‚Äì separation (if there is no marriage date), Union ‚Äì divorce (if there is a marriage date), or Observation if it a current union																						
-SAPRIN:Pregnancy	Pregnancy	The period of being pregnant. Also used to record maternity histories retrospectively		pregnancy history																				
-SAPRIN:Woman	Woman	The individual identifier of the woman who experienced the pregnancy		pregnancy history																				
-SAPRIN:ANCVisits	ANCVisits	The number of antenatal care visits during this pregnancy		pregnancy history																				
-SAPRIN:Duration	Duration	Duration in weeks of the pregnancy		pregnancy history																				
-SAPRIN:Outcome	Outcome	A delivery event or Observation if the pregnancy is still current at the time of observation		pregnancy history																				
-SAPRIN:Social_support	Social support	The period during which an individual receives a government social support grant																						
-SAPRIN:Grantholder	Grantholder	The individual identifier of the person holding the grant																						
-SAPRIN:Beneficiary	Beneficiary	The individual identifier of the intended beneficiary of the grant. This may be the same as the identifier of the grant holder in the case where the holder is the beneficiary, e.g. old age pension, or different as in the case of care dependency grants, where the grant holder receives the grant on behalf of someone else, e.g. a child																						
-SAPRIN:Type_Social_support	Type (Social support)	The type of grant																						
-SAPRIN:StartDate	StartDate	The start date of the social support																						
-SAPRIN:EndDate	EndDate	The end date of the social support																						
-SAPRIN:StatusObservation	StatusObservation	Information collected at a particular observation, valid only at the time of the observation. State may be imputed between consecutive status observations but is not known to be valid. This is in contrast with episode where the assertion is that the state represented by the episode is valid for the duration of the episode.																						
-SAPRIN:Individual_StatusObservation	Individual StatusObservation	A set of data elements collected about an individual either during a face-to-face visit or telephonic interview with the individual or from a proxy informant																						
-SAPRIN:Individual_Individual_StatusObservation	Individual (Individual StatusObservation)	The unique individual identifier of the subject of the status observation																						
-SAPRIN:Observation_Individual_StatusObservation	Observation (Individual StatusObservation)	The observation at which the status observation was made																						
-SAPRIN:ResidentStatus	ResidentStatus	Physical presence in the dwelling, recorded as the number of months since the previous observation visit		residence																				
-SAPRIN:MotherStatus	MotherStatus																							
-SAPRIN:FatherStatus	FatherStatus																							
-SAPRIN:HighestSchoolLevelCompleted	HighestSchoolLevelCompleted	Grade 1 ‚Äì 12		education																				
-SAPRIN:HighestNonSchoolEducation	HighestNonSchoolEducation			education																				
-SAPRIN:CurrentEducation	CurrentEducation	If the individual is currently attending an educational institution, at what level:		education																				
-SAPRIN:Currently_employed	Currently employed			occupation																				
-SAPRIN:Not_employed	Not employed	Type/reason for unemployment		occupation																				
-SAPRIN:EmploymentSector	EmploymentSector			occupation																				
-SAPRIN:EmploymentType	EmploymentType			occupation																				
-SAPRIN:Employer	Employer			occupation																				
-SAPRIN:FinancialStatus	FinancialStatus	Self-reported financial status																						
-SAPRIN:MaritalStatus	MaritalStatus			marital status value																				
-SAPRIN:PartnershipStatus	PartnershipStatus																							
-SAPRIN:HealthStatus	HealthStatus	Self-reported health status																						
-SAPRIN:Tuberculosis	Tuberculosis			diagnosis of tuberculosis																				
-SAPRIN:HIV	HIV			diagnosis of HIV																				
-SAPRIN:If_HIVPos	If HIV+			diagnosis of HIV																				
-SAPRIN:If_HIVNeg	If HIV-	i. When last HIV- result (>1yr, <1yr ago)		diagnosis of HIV																				
-SAPRIN:HIVResult	HIVResult	HIV serostatus from dried blood spot		diagnosis of HIV																				
-SAPRIN:Hypertension	Hypertension			diagnosis of hypertension																				
-SAPRIN:Diabetes	Diabetes			diagnosis of diabetes																				
-SAPRIN:Health_care_utilisation	Health care utilisation																							
-SAPRIN:Vaccination_history	Vaccination history (child <=6yr)	For each vaccination record: date received and source of information (Road to Health Card or recall)																						
-SAPRIN:Household_Status_Observation	Household Status Observation	Set of data elements collected from a household informant, during a face to face or telephonic interview																						
-SAPRIN:Water_source	Water source	The most commonly used (during last year) source of drinking water																						
-SAPRIN:Toilet	Toilet	What kind of toilet does the household use																						
-SAPRIN:Electricity_supply	Electricity supply	Is the household connected to the electricity grid?																						
-SAPRIN:Cooking_fuel	Cooking fuel	What is the main fuel used for cooking?																						
-SAPRIN:Dwelling_construction	Dwelling construction	What is the construction materials of the walls?
- What is the construction material of the floor?
- How many bedrooms does your household occupy at this dwelling?																						
-SAPRIN:Assets	Assets	Does the household have any of the following items in good working order?																						
-SAPRIN:Crime	Crime	Has any resident member of the household been a victim of any of these crimes in the past 12 months?																						
-SAPRIN:Financial_situation	Financial situation	How would the household classify its financial situation these days?																						
-SAPRIN:Food_security	Food security	In the last 12 months did you or any other member of your household ever cut the size of your meals or skip meals because there was not enough money for food?																						
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
-																								
+Field ID	Field Label	Class Type	GECKO Label	Comment																			
+ID	LABEL	CLASS_TYPE	C % SPLIT=|																				
+SAPRIN:Base_Entities	Base Entities																						
+SAPRIN:Location	Location																						
+SAPRIN:Type_Location	Type (Location)																						
+SAPRIN:Area	Area																						
+SAPRIN:Coordinate	Coordinate																						
+SAPRIN:Household	Household		residence																				
+SAPRIN:Identifier_Household	Identifier (Household)		residence																				
+SAPRIN:Individual	Individual		family and household structure																				
+SAPRIN:Identifier_Individual	Identifier (Individual)																						
+SAPRIN:External_identifier_Individual	External identifier (Individual)																						
+SAPRIN:Surname	Surname																						
+SAPRIN:Alternative_surname	Alternative surname																						
+SAPRIN:First_name_1	First name 1																						
+SAPRIN:First_name_2	First name 2																						
+SAPRIN:Civilian_ID_number	Civilian ID number																						
+SAPRIN:Citizenship	Citizenship		residence																				
+SAPRIN:Nationality	Nationality		ethnicity/race																				
+SAPRIN:Sex	Sex		biological sex																				
+SAPRIN:Birth_Individual	Birth (Individual)																						
+SAPRIN:EndEvent_Individual	EndEvent (Individual)																						
+SAPRIN:MotherId	MotherId																						
+SAPRIN:FatherId	FatherId																						
+SAPRIN:MotherSurname	MotherSurname																						
+SAPRIN:MotherFirstName	MotherFirstName																						
+SAPRIN:FatherSurname	FatherSurname																						
+SAPRIN:FatherFirstName	FatherFirstName																						
+SAPRIN:Events	Events																						
+SAPRIN:Migration	Migration		residence	Maybe?																			
+SAPRIN:Date_Migration	Date (Migration)		residence	Maybe?																			
+SAPRIN:Type_Migration	Type (Migration)		residence	Maybe?																			
+SAPRIN:Direction	Direction		residence	Maybe?																			
+SAPRIN:Origin	Origin		residence	Maybe?																			
+SAPRIN:Destination	Destination		residence	Maybe?																			
+SAPRIN:Unit	Unit																						
+SAPRIN:Birth	Birth																						
+SAPRIN:Date_Birth	Date (Birth)		age/birthdate																				
+SAPRIN:Birth_weight	Birth weight																						
+SAPRIN:BirthCertificate	BirthCertificate																						
+SAPRIN:DateRegistered	DateRegistered																						
+SAPRIN:PregnancyOutcome	PregnancyOutcome		pregnancy history																				
+SAPRIN:Date_PregnancyOutcome	Date (PregnancyOutcome)		pregnancy history																				
+SAPRIN:Type_PregnancyOutcome	Type (PregnancyOutcome)		pregnancy history																				
+SAPRIN:Place_PregnancyOutcome	Place (PregnancyOutcome)		pregnancy history																				
+SAPRIN:BirthAttendant	BirthAttendant		pregnancy history																				
+SAPRIN:LiveBirths	LiveBirths		pregnancy history																				
+SAPRIN:Stillborn	Stillborn		pregnancy history																				
+SAPRIN:Death	Death																						
+SAPRIN:Date_Death	Date (Death)																						
+SAPRIN:Place_Death	Place (Death)																						
+SAPRIN:DeathCertificate	DeathCertificate																						
+SAPRIN:Verbal_autopsy	Verbal autopsy																						
+SAPRIN:Enumeration	Enumeration																						
+SAPRIN:Date_Enumeration	Date (Enumeration)																						
+SAPRIN:Membership_Events	Membership Events																						
+SAPRIN:Date_Membership_Events	Date (Membership Events)																						
+SAPRIN:Type_Membership_Events	Type (Membership Events)																						
+SAPRIN:Household_Headship	Household Headship		family and household structure																				
+SAPRIN:Date_Household_Headship	Date (Household Headship)																						
+SAPRIN:Type_Household_Headship	Type (Household Headship)																						
+SAPRIN:UnionEvent	UnionEvent																						
+SAPRIN:Date_UnionEvent	Date (UnionEvent)																						
+SAPRIN:Type_UnionEvent	Type (UnionEvent)																						
+SAPRIN:Observation	Observation																						
+SAPRIN:Date_Observation	Date (Observation)																						
+SAPRIN:Location_Observation	Location (Observation)																						
+SAPRIN:DataCollector	DataCollector																						
+SAPRIN:Respondent	Respondent																						
+SAPRIN:Episodes	Episodes																						
+SAPRIN:Residence	Residence																						
+SAPRIN:Individual_Residence	Individual (Residence)																						
+SAPRIN:Location_Residence	Location (Residence)																						
+SAPRIN:StartEvent_Residence	StartEvent (Residence)																						
+SAPRIN:EndEvent_Residence	EndEvent (Residence)																						
+SAPRIN:HouseholdResidence	HouseholdResidence																						
+SAPRIN:Household_HouseholdResidence	Household (HouseholdResidence)																						
+SAPRIN:Location_HouseholdResidence	Location (HouseholdResidence)																						
+SAPRIN:External_identifier_HouseholdResidence	External identifier (HouseholdResidence)																						
+SAPRIN:StartEvent_HouseholdResidence	StartEvent (HouseholdResidence)																						
+SAPRIN:EndEvent_HouseholdResidence	EndEvent (HouseholdResidence)																						
+SAPRIN:Membership_Episodes	Membership Episodes																						
+SAPRIN:Individual_Membership_Episodes	Individual (Membership Episodes)																						
+SAPRIN:Household_Membership_Episodes	Household (Membership Episodes)																						
+SAPRIN:StartEvent_Membership_Episodes	StartEvent (Membership Episodes)																						
+SAPRIN:EndEvent_Membership_Episodes	EndEvent (Membership Episodes)																						
+SAPRIN:Household_Head_Relationship	Household Head Relationship																						
+SAPRIN:Membership_Household_Head_Relationship	Membership (Household Head Relationship)																						
+SAPRIN:Relationship	Relationship																						
+SAPRIN:StartEvent_Household_Head_Relationship	StartEvent (Household Head Relationship)																						
+SAPRIN:EndEvent_Household_Head_Relationship	EndEvent (Household Head Relationship)																						
+SAPRIN:Union	Union																						
+SAPRIN:Individual1	Individual1																						
+SAPRIN:Individual2	Individual2																						
+SAPRIN:StartEvent_Union	StartEvent (Union)																						
+SAPRIN:MarriageDate	MarriageDate																						
+SAPRIN:EndEvent_Union	EndEvent (Union)																						
+SAPRIN:Pregnancy	Pregnancy		pregnancy history																				
+SAPRIN:Woman	Woman		pregnancy history																				
+SAPRIN:ANCVisits	ANCVisits		pregnancy history																				
+SAPRIN:Duration	Duration		pregnancy history																				
+SAPRIN:Outcome	Outcome		pregnancy history																				
+SAPRIN:Social_support	Social support																						
+SAPRIN:Grantholder	Grantholder																						
+SAPRIN:Beneficiary	Beneficiary																						
+SAPRIN:Type_Social_support	Type (Social support)																						
+SAPRIN:StartDate	StartDate																						
+SAPRIN:EndDate	EndDate																						
+SAPRIN:StatusObservation	StatusObservation																						
+SAPRIN:Individual_StatusObservation	Individual StatusObservation																						
+SAPRIN:Individual_Individual_StatusObservation	Individual (Individual StatusObservation)																						
+SAPRIN:Observation_Individual_StatusObservation	Observation (Individual StatusObservation)																						
+SAPRIN:ResidentStatus	ResidentStatus		residence																				
+SAPRIN:MotherStatus	MotherStatus																						
+SAPRIN:FatherStatus	FatherStatus																						
+SAPRIN:HighestSchoolLevelCompleted	HighestSchoolLevelCompleted		education																				
+SAPRIN:HighestNonSchoolEducation	HighestNonSchoolEducation		education																				
+SAPRIN:CurrentEducation	CurrentEducation		education																				
+SAPRIN:Currently_employed	Currently employed		occupation																				
+SAPRIN:Not_employed	Not employed		occupation																				
+SAPRIN:EmploymentSector	EmploymentSector		occupation																				
+SAPRIN:EmploymentType	EmploymentType		occupation																				
+SAPRIN:Employer	Employer		occupation																				
+SAPRIN:FinancialStatus	FinancialStatus																						
+SAPRIN:MaritalStatus	MaritalStatus		marital status value																				
+SAPRIN:PartnershipStatus	PartnershipStatus																						
+SAPRIN:HealthStatus	HealthStatus																						
+SAPRIN:Tuberculosis	Tuberculosis		diagnosis of tuberculosis																				
+SAPRIN:HIV	HIV		diagnosis of HIV																				
+SAPRIN:If_HIVPos	If HIV+		diagnosis of HIV																				
+SAPRIN:If_HIVNeg	If HIV-		diagnosis of HIV																				
+SAPRIN:HIVResult	HIVResult		diagnosis of HIV																				
+SAPRIN:Hypertension	Hypertension		diagnosis of hypertension																				
+SAPRIN:Diabetes	Diabetes		diagnosis of diabetes																				
+SAPRIN:Health_care_utilisation	Health care utilisation																						
+SAPRIN:Vaccination_history	Vaccination history (child <=6yr)																						
+SAPRIN:Household_Status_Observation	Household Status Observation																						
+SAPRIN:Water_source	Water source																						
+SAPRIN:Toilet	Toilet																						
+SAPRIN:Electricity_supply	Electricity supply																						
+SAPRIN:Cooking_fuel	Cooking fuel																						
+SAPRIN:Dwelling_construction	Dwelling construction																						
+SAPRIN:Assets	Assets																						
+SAPRIN:Crime	Crime																						
+SAPRIN:Financial_situation	Financial situation																						
+SAPRIN:Food_security	Food security																						

--- a/mappings/saprin-mapping.tsv
+++ b/mappings/saprin-mapping.tsv
@@ -1,0 +1,1007 @@
+Field ID	Field Label	Definition	Class Type	GECKO Label	Comment																			
+ID	LABEL		CLASS_TYPE	C % SPLIT=|																				
+SAPRIN:Base_Entities	Base Entities	The core entities on which longitudinal data will be collected. Each entity has a dated start and end event																						
+SAPRIN:Location	Location	A place to which geo-coordinates can be assigned																						
+SAPRIN:Type_Location	Type (Location)																							
+SAPRIN:Area	Area	Village or other higher level spatial grouping of locations																						
+SAPRIN:Coordinate	Coordinate	Latitude and longitude on the WGS84 coordinate system																						
+SAPRIN:Household	Household	A household resident at a location within the boundary of the surveillance area. A household is defined as a social group of one or more individual members. Resident household members share the same dwelling as the household, non-resident household members are individuals who do not share the same dwelling as the household, but who eat from the same pot when they are present in the household‚Äôs dwelling.		residence																				
+SAPRIN:Identifier_Household	Identifier (Household)	A unique household identifier which the household retains irrespective of its current residence		residence																				
+SAPRIN:Individual	Individual	Household members, where a resident is a member of a household who normally lives (i.e. intends to sleep the majority of the time) at the same dwelling as the household; and a non-resident is a member of a household who does not normally live at the same dwelling as the household but is nevertheless considered a member of the household.		family and household structure																				
+SAPRIN:Identifier_Individual	Identifier (Individual)	A globally unique identifier used internally to uniquely identify the individual																						
+SAPRIN:External_identifier_Individual	External identifier (Individual)	An identifier used on data collection instruments to uniquely identify the individual, but is removed together with other personally identifiable information when data is made available for analysis																						
+SAPRIN:Surname	Surname	Family or last name																						
+SAPRIN:Alternative_surname	Alternative surname	An alternative surname (formerly) used by the individual, e.g. maiden name																						
+SAPRIN:First_name_1	First name 1	The first given name of the individual																						
+SAPRIN:First_name_2	First name 2	The second/alternative given name of the individual																						
+SAPRIN:Civilian_ID_number	Civilian ID number	The 13-digit South African civilian identity number																						
+SAPRIN:Citizenship	Citizenship	The country of which the individual is a citizen		residence																				
+SAPRIN:Nationality	Nationality	The country of origin of the individual (the country of which the person is/was a citizen by birth)		ethnicity/race																				
+SAPRIN:Sex	Sex	Male (1), female(2) or unknown(0)		biological sex																				
+SAPRIN:Birth_Individual	Birth (Individual)	The Birth event of this individual or the DeliveryEvent resulting in the birth of this individual if the individual enters surveillance through birth																						
+SAPRIN:EndEvent_Individual	EndEvent (Individual)	The death event of this individual or the Observation at which this individual was last observed																						
+SAPRIN:MotherId	MotherId	The unique identifier of the mother of the individual, if the mother is enumerated in the surveillance																						
+SAPRIN:FatherId	FatherId	The unique identifier of the father of the individual, if the father is enumerated in the surveillance																						
+SAPRIN:MotherSurname	MotherSurname	The surname of the mother of the individual																						
+SAPRIN:MotherFirstName	MotherFirstName	The first name/s of the mother																						
+SAPRIN:FatherSurname	FatherSurname	The surname of the father of the individual																						
+SAPRIN:FatherFirstName	FatherFirstName	The first name/s of the father																						
+SAPRIN:Events	Events	Demographic events that delineate episodes of observation during longitudinal surveillance																						
+SAPRIN:Migration	Migration	A change in location of usual residence		residence	Maybe?																			
+SAPRIN:Date_Migration	Date (Migration)	Date of migration		residence	Maybe?																			
+SAPRIN:Type_Migration	Type (Migration)			residence	Maybe?																			
+SAPRIN:Direction	Direction			residence	Maybe?																			
+SAPRIN:Origin	Origin	Origin of the migration (location)		residence	Maybe?																			
+SAPRIN:Destination	Destination	Destination of the migration (location)		residence	Maybe?																			
+SAPRIN:Unit	Unit	Individual or household																						
+SAPRIN:Birth	Birth	The birth event of an individual																						
+SAPRIN:Date_Birth	Date (Birth)	Date of birth		age/birthdate																				
+SAPRIN:Birth_weight	Birth weight	Birth weight as obtained from the Road to Health card in grams																						
+SAPRIN:BirthCertificate	BirthCertificate	Whether the birth certificate was observed																						
+SAPRIN:DateRegistered	DateRegistered	The date on which the birth was registered, or null if the birth hasn‚Äôt been registered yet																						
+SAPRIN:PregnancyOutcome	PregnancyOutcome	The end event of a pregnancy		pregnancy history																				
+SAPRIN:Date_PregnancyOutcome	Date (PregnancyOutcome)	Date of birth		pregnancy history																				
+SAPRIN:Type_PregnancyOutcome	Type (PregnancyOutcome)	Types i-ii is only applicable if the pregnancy end prior to the 28th week of pregnancy, types iii-v is applicable only on or after the 28th week of pregnancy		pregnancy history																				
+SAPRIN:Place_PregnancyOutcome	Place (PregnancyOutcome)			pregnancy history																				
+SAPRIN:BirthAttendant	BirthAttendant			pregnancy history																				
+SAPRIN:LiveBirths	LiveBirths	The number of babies born alive resulting from this delivery		pregnancy history																				
+SAPRIN:Stillborn	Stillborn	The number of still born babies resulting from this delivery		pregnancy history																				
+SAPRIN:Death	Death	The death of an individual																						
+SAPRIN:Date_Death	Date (Death)	The date of the death																						
+SAPRIN:Place_Death	Place (Death)																							
+SAPRIN:DeathCertificate	DeathCertificate	Observed																						
+SAPRIN:Verbal_autopsy	Verbal autopsy	WHO standard verbal autopsy questionnaire items. SAPRIN will adopt the worldwide standardised World Health Organisation (WHO) Verbal Autopsy questionnaires to determine the cause of deaths reported in the surveillance population. The latest version of the WHO Verbal Autopsy Questionnaire is 2016, edited and cognitively tested to facilitate the use of publicly available analytical software for assigning the cause of death.																						
+SAPRIN:Enumeration	Enumeration	The initial event at enumeration of an entity. Can only be used during the base census of the demographic surveillance, or when a new area is added to the surveillance																						
+SAPRIN:Date_Enumeration	Date (Enumeration)	Date of enumeration																						
+SAPRIN:Membership_Events	Membership Events	A change in household membership																						
+SAPRIN:Date_Membership_Events	Date (Membership Events)	The date of the change																						
+SAPRIN:Type_Membership_Events	Type (Membership Events)																							
+SAPRIN:Household_Headship	Household Headship	A change in the head of the household		family and household structure																				
+SAPRIN:Date_Household_Headship	Date (Household Headship)	The date of the change																						
+SAPRIN:Type_Household_Headship	Type (Household Headship)																							
+SAPRIN:UnionEvent	UnionEvent	A change in the union (conjugal relationship) between two individuals																						
+SAPRIN:Date_UnionEvent	Date (UnionEvent)	The date of the event																						
+SAPRIN:Type_UnionEvent	Type (UnionEvent)																							
+SAPRIN:Observation	Observation	A surveillance visit at a location																						
+SAPRIN:Date_Observation	Date (Observation)	Visit date																						
+SAPRIN:Location_Observation	Location (Observation)	Location where the visit took place																						
+SAPRIN:DataCollector	DataCollector	The person responsible for data collection during the visit																						
+SAPRIN:Respondent	Respondent	The primary respondent at the visit																						
+SAPRIN:Episodes	Episodes	Used to record associations longitudinally between base entities. Episodes are always started and ended through events.																						
+SAPRIN:Residence	Residence	An episode during which an individual is resident (sleeping most of the time there) at a particular location that falls within the surveillance area. An individual can only be resident at one location at a time, i.e. residency episodes cannot overlap																						
+SAPRIN:Individual_Residence	Individual (Residence)	The individual identifier																						
+SAPRIN:Location_Residence	Location (Residence)	The location identifier																						
+SAPRIN:StartEvent_Residence	StartEvent (Residence)	The event that started the episode, can only be Enumeration, Birth, Migration (Direction: In)																						
+SAPRIN:EndEvent_Residence	EndEvent (Residence)	The event that terminated the episode, can only be Death, Migration (Direction: Out) and Observation (in which the implication is that the individual is last known to be resident)																						
+SAPRIN:HouseholdResidence	HouseholdResidence	An episode during which a household is resident at a particular location that falls within the surveillance area. A household can only be resident at one location at a time, i.e. residency episodes cannot overlap																						
+SAPRIN:Household_HouseholdResidence	Household (HouseholdResidence)	The household identifier																						
+SAPRIN:Location_HouseholdResidence	Location (HouseholdResidence)	The location identifier																						
+SAPRIN:External_identifier_HouseholdResidence	External identifier (HouseholdResidence)	The identifier associated with the household during this residence																						
+SAPRIN:StartEvent_HouseholdResidence	StartEvent (HouseholdResidence)	The event that started the episode, can only be Enumeration, Household formation, Migration (Direction: In)																						
+SAPRIN:EndEvent_HouseholdResidence	EndEvent (HouseholdResidence)	The event that terminated the episode, can only be Household dissolution, Migration (Direction: Out) and Observation (in which the implication is that the household is last known to be resident)																						
+SAPRIN:Membership_Episodes	Membership Episodes	An episode during which an individual is a member of a household. An individual must be a member of at least one household to be under surveillance. An individual can be a member of more than one household at a time (membership episodes may overlap). In the case of multiple memberships, the designated household of an individual will be the household the individual is co-resident with, ranked according to the closeness of the members relationship to the household head (self, spouse, child, grandchild, parent, sibling, other relationship)																						
+SAPRIN:Individual_Membership_Episodes	Individual (Membership Episodes)	The individual identifier																						
+SAPRIN:Household_Membership_Episodes	Household (Membership Episodes)	The household identifier																						
+SAPRIN:StartEvent_Membership_Episodes	StartEvent (Membership Episodes)	The event that started the episode, can only be Enumeration, Birth or Membership start																						
+SAPRIN:EndEvent_Membership_Episodes	EndEvent (Membership Episodes)	The event that ended the episode, can only be Death, Membership end or Observation (implying that the membership is current)																						
+SAPRIN:Household_Head_Relationship	Household Head Relationship	Household head relationships are linked to a household membership and record the relationship between the individual and the head of the associated household. If the head of household change, all current household members start a new household head relationship episode																						
+SAPRIN:Membership_Household_Head_Relationship	Membership (Household Head Relationship)	The household membership episode associated with this household head relationship																						
+SAPRIN:Relationship	Relationship	The relationship between the individual member (to whom the membership belongs) and the current household head of the household																						
+SAPRIN:StartEvent_Household_Head_Relationship	StartEvent (Household Head Relationship)	The event that started the episode. Can only be Enumeration, Birth, Membership start, or Household Headship start																						
+SAPRIN:EndEvent_Household_Head_Relationship	EndEvent (Household Head Relationship)	The event that ended the episode. Can only be Death, Membership end, Household Headship end or Observation																						
+SAPRIN:Union	Union	The episode during which two persons are in an informal or formal conjugal relationship. For a conjugal relationship to exist the following factors should be considered:
+ i. Shelter. Do the partners live under the same roof?
+ ii. Sexual and personal conduct. Do the partners have sexual relations; do they maintain an attitude of fidelity to each other; do they eat their meals together?
+ iii. Services. Do they share household responsibilities?
+ iv. Social. Do they participate together in social activities; does their society recognise them as a couple?
+ v. Support. Do they support each other financially?
+ vi. Children. Do they have children together?																						
+SAPRIN:Individual1	Individual1	The individual identifier of one of the parties to the union. By convention this will be the female in a heterosexual union.																						
+SAPRIN:Individual2	Individual2	The individual identifier of the second party to the union.																						
+SAPRIN:StartEvent_Union	StartEvent (Union)	The start of the union. Can only be Enumeration or Union start																						
+SAPRIN:MarriageDate	MarriageDate	The date on which the union has been formalised as a marriage																						
+SAPRIN:EndEvent_Union	EndEvent (Union)	The end of the union. Can only be Union ‚Äì partner died, Union ‚Äì separation (if there is no marriage date), Union ‚Äì divorce (if there is a marriage date), or Observation if it a current union																						
+SAPRIN:Pregnancy	Pregnancy	The period of being pregnant. Also used to record maternity histories retrospectively		pregnancy history																				
+SAPRIN:Woman	Woman	The individual identifier of the woman who experienced the pregnancy		pregnancy history																				
+SAPRIN:ANCVisits	ANCVisits	The number of antenatal care visits during this pregnancy		pregnancy history																				
+SAPRIN:Duration	Duration	Duration in weeks of the pregnancy		pregnancy history																				
+SAPRIN:Outcome	Outcome	A delivery event or Observation if the pregnancy is still current at the time of observation		pregnancy history																				
+SAPRIN:Social_support	Social support	The period during which an individual receives a government social support grant																						
+SAPRIN:Grantholder	Grantholder	The individual identifier of the person holding the grant																						
+SAPRIN:Beneficiary	Beneficiary	The individual identifier of the intended beneficiary of the grant. This may be the same as the identifier of the grant holder in the case where the holder is the beneficiary, e.g. old age pension, or different as in the case of care dependency grants, where the grant holder receives the grant on behalf of someone else, e.g. a child																						
+SAPRIN:Type_Social_support	Type (Social support)	The type of grant																						
+SAPRIN:StartDate	StartDate	The start date of the social support																						
+SAPRIN:EndDate	EndDate	The end date of the social support																						
+SAPRIN:StatusObservation	StatusObservation	Information collected at a particular observation, valid only at the time of the observation. State may be imputed between consecutive status observations but is not known to be valid. This is in contrast with episode where the assertion is that the state represented by the episode is valid for the duration of the episode.																						
+SAPRIN:Individual_StatusObservation	Individual StatusObservation	A set of data elements collected about an individual either during a face-to-face visit or telephonic interview with the individual or from a proxy informant																						
+SAPRIN:Individual_Individual_StatusObservation	Individual (Individual StatusObservation)	The unique individual identifier of the subject of the status observation																						
+SAPRIN:Observation_Individual_StatusObservation	Observation (Individual StatusObservation)	The observation at which the status observation was made																						
+SAPRIN:ResidentStatus	ResidentStatus	Physical presence in the dwelling, recorded as the number of months since the previous observation visit		residence																				
+SAPRIN:MotherStatus	MotherStatus																							
+SAPRIN:FatherStatus	FatherStatus																							
+SAPRIN:HighestSchoolLevelCompleted	HighestSchoolLevelCompleted	Grade 1 ‚Äì 12		education																				
+SAPRIN:HighestNonSchoolEducation	HighestNonSchoolEducation			education																				
+SAPRIN:CurrentEducation	CurrentEducation	If the individual is currently attending an educational institution, at what level:		education																				
+SAPRIN:Currently_employed	Currently employed			occupation																				
+SAPRIN:Not_employed	Not employed	Type/reason for unemployment		occupation																				
+SAPRIN:EmploymentSector	EmploymentSector			occupation																				
+SAPRIN:EmploymentType	EmploymentType			occupation																				
+SAPRIN:Employer	Employer			occupation																				
+SAPRIN:FinancialStatus	FinancialStatus	Self-reported financial status																						
+SAPRIN:MaritalStatus	MaritalStatus			marital status value																				
+SAPRIN:PartnershipStatus	PartnershipStatus																							
+SAPRIN:HealthStatus	HealthStatus	Self-reported health status																						
+SAPRIN:Tuberculosis	Tuberculosis			diagnosis of tuberculosis																				
+SAPRIN:HIV	HIV			diagnosis of HIV																				
+SAPRIN:If_HIVPos	If HIV+			diagnosis of HIV																				
+SAPRIN:If_HIVNeg	If HIV-	i. When last HIV- result (>1yr, <1yr ago)		diagnosis of HIV																				
+SAPRIN:HIVResult	HIVResult	HIV serostatus from dried blood spot		diagnosis of HIV																				
+SAPRIN:Hypertension	Hypertension			diagnosis of hypertension																				
+SAPRIN:Diabetes	Diabetes			diagnosis of diabetes																				
+SAPRIN:Health_care_utilisation	Health care utilisation																							
+SAPRIN:Vaccination_history	Vaccination history (child <=6yr)	For each vaccination record: date received and source of information (Road to Health Card or recall)																						
+SAPRIN:Household_Status_Observation	Household Status Observation	Set of data elements collected from a household informant, during a face to face or telephonic interview																						
+SAPRIN:Water_source	Water source	The most commonly used (during last year) source of drinking water																						
+SAPRIN:Toilet	Toilet	What kind of toilet does the household use																						
+SAPRIN:Electricity_supply	Electricity supply	Is the household connected to the electricity grid?																						
+SAPRIN:Cooking_fuel	Cooking fuel	What is the main fuel used for cooking?																						
+SAPRIN:Dwelling_construction	Dwelling construction	What is the construction materials of the walls?
+ What is the construction material of the floor?
+ How many bedrooms does your household occupy at this dwelling?																						
+SAPRIN:Assets	Assets	Does the household have any of the following items in good working order?																						
+SAPRIN:Crime	Crime	Has any resident member of the household been a victim of any of these crimes in the past 12 months?																						
+SAPRIN:Financial_situation	Financial situation	How would the household classify its financial situation these days?																						
+SAPRIN:Food_security	Food security	In the last 12 months did you or any other member of your household ever cut the size of your meals or skip meals because there was not enough money for food?																						
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								
+																								

--- a/mappings/vukuzazi-mapping.tsv
+++ b/mappings/vukuzazi-mapping.tsv
@@ -1,0 +1,414 @@
+Field ID	Field Label	Class Type	GECKO Label	Comment																					
+ID	LABEL	CLASS_TYPE	C % SPLIT=|																						
+VZ:BPMeasuredEver	BP Measured Ever		blood pressure																						
+VZ:HighBPInformedEver	Ever Been Informed of High BP																								
+VZ:HighBPInformed12mo	Informed of High BP in 12 Months																								
+VZ:HighBPConsult6mo	High BP Consultation 6 months																								
+VZ:HighBPTx2wks	High BP Treatment in the Last 2 Weeks																								
+VZ:BPReferralExist	Referral due to Existing High Blood Pressure																								
+VZ:BPReferralExistReason	Reasons for Referral due to Existing High Blood Pressure																								
+VZ:BPReferralNonExist	Referral due to Non Existing High Blood Pressure																								
+VZ:BPReferralNonExistReason	Reasons for Referral due to Non Existing High Blood Pressure																								
+VZ:HighBPConsultHealer	High BP Consultation With Traditional Healer																								
+VZ:HighBPHerbalCurr	Currently Taking Herbal Treatment for Raised BP																								
+VZ:BSugarMeasuredEver	Blood Sugar Measured Ever																								
+VZ:HighBSugarInformedEver	High Blood Sugar Informed Ever																								
+VZ:HighBSugarInformed12mo	High Blood Sugar Informed Past 12 Months																								
+VZ:HighBSugarConsult6mo	High Blood Sugar Consultation Past 6 months																								
+VZ:HighBSugarTx2wks	High Blood Sugar Treatment Past 2 Weeks																								
+VZ:InsulinTxCurr	Currently Taking Insulin for Diabetes		history of medication for diabetes																						
+VZ:HighBSugarConsultHealer	High Blood Sugar Consultation With Traditional Healer																								
+VZ:CholestMeasuredEver	Cholesterol Measured Ever		blood total cholesterol level value																						
+VZ:HighCholestInformedEver	High Cholesterol Informed Ever		occurrence of high cholesterol																						
+VZ:HighCholestInformed12mo	High Cholesterol Informed Past 12 Months		occurrence of high cholesterol																						
+VZ:HighCholestTx2wks	High Cholesterol Treatment Past 2 Weeks		history of medication for high cholesterol																						
+VZ:HighCholestConsultHealer	High Cholesterol Consultation With Traditional Healer		occurrence of high cholesterol																						
+VZ:HighCholestHerbalCurr	Currently Taking Herbal Treatment for Raised Cholesterol		history of medication for high cholesterol	does herbal fall under this? or should this be non-pharmocological?																					
+VZ:HeartAttackEver	Heart Attack Ever																								
+VZ:HeartAttackAspirinTxCurr	Currently Taking Aspirin Treatment																								
+VZ:HeartAttackStatinsTxCurr	Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Heart Disease																								
+VZ:ParentHistHeartAttack	Parental History of Heart Attack																								
+VZ:HadStrokeEver	History of Stroke																								
+VZ:StrokeAspirinTxCurr	Currently Taking statins (Lovastatin/Simvastatin/Atorvastatin) to prevent Stroke																								
+VZ:ParentHistStroke	Parental History of Stroke																								
+VZ:CancerTxEver	Cancer Treatment Before																								
+VZ:CurrSmoker	Currently Smoking Tobacco																								
+VZ:CurrSmokerDaily	Smoke Tobacco Products Daily																								
+VZ:StopSmoking12mo	Quit Stopping Tobacco																								
+VZ:EverSmoked	Ever Smoked Tobacco Products																								
+VZ:EverSmokedDaily	Ever Smoked Tobacco Products Daily																								
+VZ:EverConsumedAlcohol	Ever Consumed Alcohol																								
+VZ:ConsumedAlcohol12mo	Consumed Alcohol Last 12 Months																								
+VZ:StoppedAlcoholHealth	Stopped Alcohol for Health Reasons																								
+VZ:ConsumedAlcohol30d	Consumed Alcohol Last 30 days																								
+VZ:TBTxCurrent	TB Current Treatment																								
+VZ:ReceivedTBInjections	TB Current Treatment																								
+VZ:TBTxEver	Ever had TB Treatment																								
+VZ:HomesteadMemberTBEver	Homestead Member TB Ever																								
+VZ:HomesteadMemberTBCurr	Homestead (or residential plot) currently on TB treatment																								
+VZ:CoughCurr	currently have a cough?																								
+VZ:FeverCurr	Have a fever currently																								
+VZ:NightSweatsCurr	Night Sweats																								
+VZ:WeightLoss6mo	Weight Loss in 6 months																								
+VZ:OtherSymptoms	Other TB Symptoms																								
+VZ:Fatigue	Fatigue																								
+VZ:Haemoptysis	Haemoptysis																								
+VZ:Chestpain	Chestpain																								
+VZ:Lymphadenitis	Lymphadenitis																								
+VZ:TBSymptDur	Duration of the TB symptoms(weeks)																								
+VZ:HighAsthmaInformedEver	High Asthma InformededEver																								
+VZ:HighAsthmaInformed12mo	Been told of high Asthma																								
+VZ:HighhAsthmaTx2wks	Taken any medication for asthma/COPD prescribed by a doctor or other health worker																								
+VZ:BreathShortness	Shortness of breath after exercise or physical activity																								
+VZ:WakeUpBreathShortness	Wake up at night because of difficulties in breathing/shortness of breath																								
+VZ:NightWheezing	NightWheezing																								
+VZ:ReceivedHIVTestResult	Received HIV Test Result																								
+VZ:HadPosHIVResult	Had Positive HIV Result																								
+VZ:CurrentlyOnART	Currently On ART Treatment																								
+VZ:ARTDefault	Ever Defaulted ART treatment																								
+VZ:ConcurrMed1Curr	Taking Concurrent Medication 1																								
+VZ:ConcurrMed2Curr	Taking Concurrent Medication 2																								
+VZ:ConcurrMed3Curr	Taking Concurrent Medication 3																								
+VZ:ConcurrMed4Curr	Taking Concurrent Medication 4																								
+VZ:ConcurrMed2Adher	Adherence Concurrent Medication 2																								
+VZ:ConcurrMed3Adher	Adherence Concurrent Medication 3																								
+VZ:ConcurrMed4Adher	Adherence Concurrent Medication 4																								
+VZ:ConcurrMed5Adher	Adherence Concurrent Medication 5																								
+VZ:ConcurrMed1Stopped	Stopped Concurrent Medication 1																								
+VZ:ConcurrMed2Stopped	Stopped Concurrent Medication 2																								
+VZ:ConcurrMed3Stopped	Stopped Concurrent Medication 3																								
+VZ:ConcurrMed4Stopped	Stopped Concurrent Medication 4																								
+VZ:ConcurrMed5Stopped	Stopped Concurrent Medication 5																								
+VZ:IsPregant	Is Pregant																								
+VZ:AllComplete	All Complete																								
+VZ:CxrScreeningResult	Chest X Ray Screening Result																								
+VZ:ReferalBasisCxr	Chest X Referal Basis																								
+VZ:CXRScore	Chest X Ray Score																								
+VZ:SputumReferral	Sputum Referral																								
+VZ:CxrMOConclusion	Chest X Ray Medical Officer Conclusion																								
+VZ:CxrMODiagnosticOther	Chest X Ray Medical Officer Diagnostic Other																								
+VZ:CxrMOReport	Chest X Ray Medical Officer Report																								
+VZ:CxrRadiologistDiagnosticOther	Chest X Ray Radiologist Diagnostic Other																								
+VZ:CxrRadiologistReport	Chest X Ray Radiologist Report																								
+VZ:HIVElisaReview	HIV Elisa Medical Officer Review																								
+VZ:CD4Review	CD4 Medical Officer Review																								
+VZ:VLReview	Viral Load Medical Officer Review																								
+VZ:GeneXpertReview	GeneXpert Medical Officer Review																								
+VZ:RifampicinReview	Rifampicin Medical Officer Review																								
+VZ:LiquidCultureReview	LiquidCulture Medical Officer Review																								
+VZ:SolidCultureReview	SolidCulture Medical Officer Review																								
+VZ:HBA1CPercentReview	HBA1CPercent Medical Officer Review																								
+VZ:CXRInterpretation	Medical Officer CXR Interpretation																								
+VZ:CXRInterpretationDesc	Medical Officer CXR Interpretation Description																								
+VZ:MOSuggestedOutcome	Medical Officer Suggested Outcome																								
+VZ:MOFinalOutcome	Medical Officer Final Outcome																								
+VZ:MOSuggestedSecondRoundOutcome	Medical Officer Suggested Second Outcome																								
+VZ:MOSecondRoundOutcome	Medical Officer Second Round Final Outcome																								
+VZ:DiabetesMessage	Medical Officer Diabetes Message																								
+VZ:HIVMessage	Medical Officer HIV Message																								
+VZ:CxrMessage	Medical Officer Chest X-Ray Message																								
+VZ:SecondRoundMessage	Medical Officer Second Round Message																								
+VZ:MOSecondRoundMessage	System Algorythm Flaged Conditions																								
+VZ:MOAgreeSecondRoundMessage	Medical Officer Agreement with System Generated Message																								
+VZ:MOOutcomeDesc	Medical Officer Outcome Description																								
+VZ:MOSuggestedSecondCondition	Medical Officer Suggested Second Condition																								
+VZ:MOAgreeSecondRoundOutcome	Medical Officer Agreement with Second Outcome																								
+VZ:MOSecondRoundOutcomeDesc	Medical Officer Outcome Description																								
+VZ:MOConditions	Medical Officer Conditions																								
+VZ:BPReferallFU	BP Referral from Follow up Visit																								
+VZ:DiabetesReferallFU	Diabetes Referral from Follow up Visit																								
+VZ:HIVReferallFU	HIV Referral from Follow up Visit																								
+VZ:TBReferallFU	TB Referral from Follow up Visit																								
+VZ:InducedTBSputumHome	Homestead Induced TB Sputum Collected																								
+VZ:SpontTBSputumHome	Homestead Spontatneous TB Sputum Collected																								
+VZ:HomeTBSputumOutcome	Home TB Sputum Outcomeollected																								
+VZ:FUGlucose	Follow Up Glucose																								
+VZ:FUGlucoseResult	Follow Up Glucose Result																								
+VZ:FUDiabetesDiagnosis	FUDiabetesDiagnosis																								
+VZ:FUDiabetesClinicDate	Follow Up Target Clinic/Hospital Date for Diabetes																								
+VZ:FUSystolicBp	Clinical Systolic Blood pressure reading																								
+VZ:FUDiastolicBp	Clinical Diastolic Blood pressure reading																								
+VZ:FUBpDiagnosis	FUBpDiagnosis																								
+VZ:FUTBpClinicDate	Follow Up Target Clinic/Hospital for Blood Pressure																								
+VZ:FUHIVStatusInformed	Follow Up Target Clinic/Hospital Date																								
+VZ:SST1Collected	SST1 Collected																								
+VZ:SST1NotCollectedReason	SST1 Not Collected Reason																								
+VZ:EDT1Collected	EDT1 Collected																								
+VZ:EDT1NotCollectedReason	EDT1 Not Collected Reasonn																								
+VZ:EDT2Collected	EDT2 Collected																								
+VZ:EDT2NotCollectedReason	EDT2 Not Collected Reasonn																								
+VZ:EDT3_1Collected	EDT3_1 Collected																								
+VZ:EDT3_1NotCollectedReason	EDT3_1 Not Collected Reasonn																								
+VZ:EDT3_2Collected	EDT3_2 Collected																								
+VZ:EDT3_2NotCollectedReason	EDT3_2 Not Collected Reasonn																								
+VZ:PAX1Collected	PAX1 Collected																								
+VZ:PAX1NotCollectedReason	PAX1 Not Collected Reason																								
+VZ:Ssp1Collected	Ssp1 Collected																								
+VZ:SpontaneousSputumObtained	Spontaneous Sputum Obtained																								
+VZ:SpontaneousSputumNotObtainedReason	Spontaneous Sputum Not Obtained Reason																								
+VZ:InducedSputumObtained	Induced Sputum Obtained																								
+VZ:InducedSputumNotObtainedReason	Induced Sputum Not Obtained Reason																								
+VZ:SSPBottleCollected	SSP Bottle Collected																								
+VZ:InducedSputumNotObtainedOtherReasonExplain	Induced Sputum Not Obtained Other Reason Explain																								
+VZ:SwabSample1Collected	Swab Sample1 Collected																								
+VZ:SwabSample1NotCollectedReason	Swab Sample1 Not Collected Reason																								
+VZ:SwabSample2Collected	Swab Sample2 Collected																								
+VZ:SwabSample2NotCollectedReason	Swab Sample2 Not Collected Reason																								
+VZ:UrineSampleCollected	Urine Sample Collected																								
+VZ:UrineSampleNotCollectedReason	Urine Sample Not Collected Reason																								
+VZ:UrineSampleCollected	Urine Sample Collected																								
+VZ:UrineSampleNotCollectedReason	Urine Sample Not Collected Reason																								
+VZ:PregTestResult	pregnancy Test Result																								
+VZ:PregTestResultNotified	pregnancy Test Result Notified																								
+VZ:BloodGlucoseFailFU	Failed to measure Blood Glucose at Home Follow Up visit																								
+VZ:BPFailFU	Failed to measure Blood Pressure at Home Follow Up visit																								
+VZ:NewHIVReferralFailFU	Failed to refer New HIV Positive case to Clinic at Home Follow Up visit																								
+VZ:CD4LabStatus	CD4 quantity not sufficient, specimen missing, or unable to run																								
+VZ:CD4LabComment	CD4 quantity not sufficient, specimen missing, or unable to run comment																								
+VZ:HIVELisaLabStatus	HIV ELISA quantity not sufficient, specimen missing, or unable to run																								
+VZ:HIVELisaLabComment	HIV ELISA quantity not sufficient, specimen missing, or unable to run comment																								
+VZ:VLLabStatus	VL quantity not sufficient, specimen missing, or unable to run																								
+VZ:VLLabComment	VL quantity not sufficient, specimen missing, or unable to run comment																								
+VZ:HbA1LabStatus	Hb A1c quantity not sufficient, specimen missing, or unable to run																								
+VZ:HbA1LabComment	Hb A1c quantity not sufficient, specimen missing, or unable to run comment																								
+VZ:GeneXpertLabStatus	Gene Xpert quantity not sufficient, specimen missing, or unable to run																								
+VZ:GeneXpertLabComment	Gene Xpert quantity not sufficient, specimen missing, or unable to run comment																								
+VZ:MGITCultureLabStatus	MGIT culture quantity not sufficient, specimen missing, or unable to run																								
+VZ:MGITCultureLabComment	MGIT culture quantity not sufficient, specimen missing, or unable to run comment																								
+VZ:SolidCultureLabStatus	Solid culture quantity not sufficient, specimen missing, or unable to run																								
+VZ:SolidCultureLabComment	Solid culture quantity not sufficient, specimen missing, or unable to run comment																								
+VZ:PhoneCallFail	Phone Call Attempts failed to contact Participant																								
+VZ:HomeVisitFail	Home Visit Attempts failed to contact Participant																								
+VZ:SputumPosRefFail	Failed to refer Positive Sputum case to Clinic or Hospital																								
+VZ:ConsentInformedHIV	Has the participant consented to be informed about their HIV results																								
+VZ:FUCXROtherReferral	Participant Has Diagnosis Other than TB that requires referral to the clinic or hospital																								
+VZ:CancerType	Cancer Type																								
+VZ:AgeStartedSmoking	Age Started Smoking Tobacco		tobacco																						
+VZ:YearsAgoStartedSmoking	Years Ago Individual Started Smoking		tobacco																						
+VZ:MonthsAgoStartedSmoking	Months Ago Individual Started Smoking		tobacco																						
+VZ:WeeksAgoStartedSmoking	Weeks Ago Individual Started Smoking		tobacco																						
+VZ:ManufacturedCigarettesDaily	Manufactured Cigarettes Smoked Daily		tobacco																						
+VZ:ManufacturedCigarettesWeekly	Manufactured Cigarettes Smoked Weekly		tobacco																						
+VZ:HandRolledCigarettesDaily	Hand Rolled Cigarettes Smoked Daily		tobacco																						
+VZ:HandRolledCigarettesWeekly	Hand Rolled Cigarettes Smoked Weekly		tobacco																						
+VZ:PipedTobaccoDaily	Piped Tobacco Cigarettes Smoked Daily		tobacco																						
+VZ:PipedTobaccoWeekly	Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
+VZ:PipedTobaccoWeekly	Piped Tobacco Cigarettes Smoked Weekly		tobacco																						
+VZ:CigarsRcherootsDaily	Cigars or Cheroots Daily		tobacco																						
+VZ:CigarsORcherootsWeekly	Cigars or Cheroots Smoked Weekly		tobacco																						
+VZ:ShishaSessionsDaily	Cigars or Cheroots Smoked Daily		tobacco																						
+VZ:ShishaSessionsWeekly	Cigars or Cheroots Smoked Weekly		tobacco																						
+VZ:OtherTobaccoSpecifyDaily	Other Tobacco Smoked Daily		tobacco																						
+VZ:OtherTobaccoWeekly	Other Tobacco Smoked Weekly		tobacco																						
+VZ:OtherTobaccoSpecifyDailySpec	Other Tobacco Specify Daily		tobacco																						
+VZ:OtherTobaccoWeeklySpec	Other Tobacco Specify Weekly		tobacco																						
+VZ:ConsumptionFrequency	Alcohol Consumption Frequency		alcohol																						
+VZ:ConsumedAlcoholOccassions	Occassions Consumed Alcohol		alcohol																						
+VZ:DrinksConsumedOccassions	Drinks Consumed During Occassion		alcohol																						
+VZ:DrinksPerOccassion	Drinks Per Occassion		alcohol																						
+VZ:SixDrinksPerOccassion	Six Drinks Per Occassion or More Consumed		alcohol																						
+VZ:LastWeekMondayDrinks	Last Week Monday Drinks		alcohol																						
+VZ:LastWeekTuesdayDrinks	Last Week Tuesday Drinks		alcohol																						
+VZ:LastWeekWednesdayDrinks	Last Week Wednesday Drinks		alcohol																						
+VZ:LastWeekThursdayDrinks	Last Week Thursday Drinks		alcohol																						
+VZ:LastWeekFridayDrinks	Last Week Friday Drinks		alcohol																						
+VZ:LastWeekSaturdayDrinks	Last Week Saturday Drinks		alcohol																						
+VZ:LastWeekSundayDrinks	Last Week Sunday Drinks		alcohol																						
+VZ:ConsumedHomeBredAlcohol	Consumed Home Bred Alcohol		alcohol																						
+VZ:NumberHomeBredSpirits	Number Home Bred Spirits		alcohol																						
+VZ:NumberHomeBredBeer	Number Home Bred Beer		alcohol																						
+VZ:NumberAlcoholImported	Number Alcohol Imported		alcohol																						
+VZ:NumberAlcoholForbidden	Number Alcohol Forbidden		alcohol																						
+VZ:NumberAlcoholUntaxed	Number of Alcohol Untaxed		alcohol																						
+VZ:NumberTBTxEver	Number of Times On TB Treatment		history of medication for tuberculosis																						
+VZ:LastTBDateCompletion	TB Completion Date		history of medication for tuberculosis																						
+VZ:CoughDuration	Cough Duration		occurrence of cough																						
+VZ:CoughSputum	Cough Sputum		occurrence of cough																						
+VZ:FeverDuration	Fever Duration		occurrence of fever																						
+VZ:NightSweatsDuration	Night Sweats Duration		occurrence of night sweats																						
+VZ:WeightLossNumber	Weight Loss Number		occurrence of weight loss																						
+VZ:HIVPosResult1stDate	Date of First HIV Positive Result		diagnosis of HIV																						
+VZ:ARTInitiationDate	Date Of ART Initiation																								
+VZ:ARTDefaultTimes	Number of Times ART Defaulted																								
+VZ:LastHIVNegResultDate	Date of Last HIV Negative Result		diagnosis of HIV																						
+VZ:Medication1	Medication 1																								
+VZ:Medication2	Medication 2																								
+VZ:Medication3	Medication 3																								
+VZ:Medication4	Medication 4																								
+VZ:Medication5	Medication 5																								
+VZ:Medication6	Medication 6																								
+VZ:Medication7	Medication 7																								
+VZ:Medication8	Medication 8																								
+VZ:Medication1StartDate	Medication 1 Start Date																								
+VZ:Medication2StartDate	Medication 2 Start Date																								
+VZ:Medication3StartDate	Medication 3 Start Date																								
+VZ:Medication4StartDate	Medication 4 Start Date																								
+VZ:Medication5StartDate	Medication 5 Start Date																								
+VZ:Medication6StartDate	Medication 6 Start Date																								
+VZ:Medication7StartDate	Medication 7 Start Date																								
+VZ:Medication8StartDate	Medication 8 Start Date																								
+VZ:Medication9StartDate	Medication 9 Start Date																								
+VZ:ConcurrMed1	Concurrent Medication 1																								
+VZ:ConcurrMed2	Concurrent Medication 2																								
+VZ:ConcurrMed3	Concurrent Medication 3																								
+VZ:ConcurrMed4	Concurrent Medication 4																								
+VZ:ConcurrMed5	Concurrent Medication 5																								
+VZ:ConcurrMedIndica1	Concurrent Medication Indication 1																								
+VZ:ConcurrMedIndica2	Concurrent Medication Indication 2																								
+VZ:ConcurrMedIndica3	Concurrent Medication Indication 3																								
+VZ:ConcurrMedIndica4	Concurrent Medication Indication 4																								
+VZ:ConcurrMedIndica5	Concurrent Medication Indication 5																								
+VZ:ConcurrMed1StartDate	Concurrent Medication 1 Start Date																								
+VZ:ConcurrMed2StartDate	Concurrent Medication 2 Start Date																								
+VZ:ConcurrMed3StartDate	Concurrent Medication 3 Start Date																								
+VZ:ConcurrMed4StartDate	Concurrent Medication 4 Start Date																								
+VZ:ConcurrMed5StartDate	Concurrent Medication 5 Start Date																								
+VZ:ConcurrMed5Curr	Taking Concurrent Medication 5																								
+VZ:ConcurrMed1Adher	Adherence Concurrent Medication 1																								
+VZ:TimeLastMeal	Time Last Meal																								
+VZ:LastMenstrualDate	Date of Last Menstrual																								
+VZ:FoodVoucherId	Food Voucher Id																								
+VZ:FoodPackId	Food Pack Id																								
+VZ:NotAllCompleteReaons	Not All Complete Reasons																								
+VZ:SST1	SST1																								
+VZ:EDT1	EDT1																								
+VZ:EDT2	EDT2																								
+VZ:EDT3_1	EDT3_1																								
+VZ:EDT3_2	EDT3_2																								
+VZ:PAX1	PAX1																								
+VZ:Ssp1	Ssp1																								
+VZ:SSPBottle	SSPBottle																								
+VZ:SwabSample1CollectedId	Swab Sample1 Collected Id																								
+VZ:SwabSample2CollectedId	Swab Sample2 Collected Id																								
+VZ:UrineSampleCollectedId	Urine Sample Collected Id		urine																						
+VZ:UrineSampleCollectedId	Urine Sample Collected Id		urine																						
+VZ:PregTestDeviceId	pregnancy Test Device Id																								
+VZ:CxrRadiologistConclusion	Chest X Ray Radiologist Conclusion																								
+VZ:MOLungField	Medical Officer LungFields																								
+VZ:RadiologistLungField	Radiologist LungFields																								
+VZ:UrineRefusal	Refused Urine Sample COllection																								
+VZ:HeightCm	Height in Cm		height																						
+VZ:WeightKg	Weight in Kg		weight																						
+VZ:WaistCircumferenceCm	Waist Circumference in Cm		waist circumference value																						
+VZ:BPCuffSize	BP Cuff Size																								
+VZ:BPFirstSystolic	BP First Systolic																								
+VZ:BPFirstDiastolic	BP First Diastolic																								
+VZ:BPSecondSystolic	BP Second Systolic																								
+VZ:BPSecondDiastolic	BP Second Diastolic																								
+VZ:BPThirdSystolic	BP Third Systolic																								
+VZ:BPThirdDiastolic	BP Third Diastolic																								
+VZ:BPForthSystolic	BP Forth Systolic																								
+VZ:BPForthDiastolic	BP Forth Diastolic																								
+VZ:LowestBpSystolic	BP Lowest Systolic																								
+VZ:LowestBpDiastolic	BP Lowest Diastolic																								
+VZ:HipCircumference	Hip Circumference		hip circumference value																						
+VZ:ArmCircumference	Arm Circumference																								
+VZ:HeartRateFirstReading	Heart Rate First Reading		heart rate																						
+VZ:HeartRateSecondReading	Heart Rate Second Reading		heart rate																						
+VZ:HeartRateThirdReading	Heart RateThird Reading		heart rate																						
+VZ:HeartRateForthReading	Heart Rate Forth Reading		heart rate																						
+VZ:Pregnant	Pregnant		pregnancy history																						
+VZ:ActiveTB	CXR proposed diagnostic-ActiveTB		diagnosis of tuberculosis																						
+VZ:OldTB	CXR proposed diagnostic-OldTB		diagnosis of tuberculosis																						
+VZ:ProbableTB	CXR proposed diagnostic-ProbableTB		diagnosis of tuberculosis																						
+VZ:OtherInfection	CXR proposed diagnostic-OtherInfection																								
+VZ:InflammatoryDisorder	CXR proposed diagnostic-InflammatoryDisorder																								
+VZ:Neoplasm	CXR proposed diagnostic-Neoplasm																								
+VZ:Trauma	CXR proposed diagnostic-Trauma																								
+VZ:CongenitalAbnormality	CXR proposed diagnostic-CongenitalAbnormality																								
+VZ:CardiacDisorder	CXR proposed diagnostic-CardiacDisorder																								
+VZ:VascularDisorder	CXR proposed diagnostic-VascularDisorder																								
+VZ:DegenerativeDisorder	CXR proposed diagnostic-DegenerativeDisorder																								
+VZ:LeftLung	CXR pattern Left lung field & pleura																								
+VZ:RightLung	CXR pattern Right lung field & pleura																								
+VZ:TBDiagnosticOther	TB Diagnostic Other		diagnosis of tuberculosis																						
+VZ:MOTBDiagnosticOther	Medical Officer Diagnostic TB Diagnostic Other		diagnosis of tuberculosis																						
+VZ:RadLeftLungNormal	Radiologist Left Lung Normal																								
+VZ:RadLeftLungConsolid	Radiologist Left Lung Consolidation																								
+VZ:RadLeftLungCavitation	Radiologist Left Lung Cavitation																								
+VZ:RadLeftLungNodules	Radiologist Left Lung Nodules																								
+VZ:RadLeftLungMass	Radiologist Left Lung Mass																								
+VZ:RadLeftLungReticular	Radiologist Left Lung ReticularOpacities																								
+VZ:RadLeftLungFibrosis	Radiologist Left Lung Fibrosis																								
+VZ:RadLeftLungCalcification	Radiologist Left Lung Calcification																								
+VZ:RadLeftLungPleuralThick	Radiologist Left Lung Pleural Thickening																								
+VZ:RadLeftLungPleuralEffusion	Radiologist Left Lung PleuralEffusion																								
+VZ:RadLeftLungNodeEnlarge	Radiologist Left Lung Node Enlargement																								
+VZ:RadLeftLungOther	Radiologist Left Lung Other																								
+VZ:RadRightLungNormal	Radiologist Right Lung Normal																								
+VZ:RadRightLungConsolid	Radiologist Right Lung Consolidation																								
+VZ:RadRightLungCavitation	Radiologist Right Lung Cavitation																								
+VZ:RadRightLungNodules	Radiologist Right Lung Nodules																								
+VZ:RadRightLungMass	Radiologist Right Lung Mass																								
+VZ:RadRightLungReticular	Radiologist Right Lung ReticularOpacities																								
+VZ:RadRightLungFibrosis	Radiologist Right Lung Fibrosis																								
+VZ:RadRightLungCalcification	Radiologist Right Lung Calcification																								
+VZ:RadRightLungPleuralThick	Radiologist Right Lung Pleural Thickening																								
+VZ:RadRightLungPleuralEffusion	Radiologist Right Lung Pleural Effusion																								
+VZ:RadRightLungNodeEnlarge	Radiologist Right Lung Node Enlargement																								
+VZ:RadRightLungOther	Radiologist Right Lung Other																								
+VZ:WillingSurveyedAttempt1	Willing Surveyed Attempt 1																								
+VZ:RadActiveTB	Radiologist Diagnostic ActiveTB		diagnosis of tuberculosis																						
+VZ:RadOldTB	Radiologist Diagnostic OldTB		diagnosis of tuberculosis																						
+VZ:RadProbableTB	Radiologist Diagnostic ProbableTB		diagnosis of tuberculosis																						
+VZ:RadOtherInfection	Radiologist Diagnostic Other Infection																								
+VZ:RadInflammatoryDisorder	Radiologist Diagnostic Inflammatory Disorder																								
+VZ:RadNeoplasm	Radiologistr Diagnostic Neoplasm																								
+VZ:RadTrauma	Radiologist Diagnostic Trauma																								
+VZ:RadCongenitalAbnormality	Radiologist Diagnostic CongenitalAbnormality																								
+VZ:RadCardiacDisorder	Radiologist Diagnostic CardiacDisorder																								
+VZ:RadVascularDisorder	Radiologist Diagnostic VascularDisorder																								
+VZ:RadDegenerativeDisorder	Radiologist Diagnostic Degenerative Disorder																								
+VZ:RadTBDiagnosticOther	Radiologist TB Diagnostic Other		diagnosis of tuberculosis																						
+VZ:LabResultDate	Lab Result Date																								
+VZ:AbnormalResult	Is Result Abnormal?																								
+VZ:ClinicalReview	Needs Clinical Review?																								
+VZ:CD4LymphPercent	CD4 Lymphocytes %																								
+VZ:CD4LymphAb	CD4 Lymphocytes Abs																								
+VZ:CD4CD8Ratio	CD4/CD8 Ratio																								
+VZ:CD8LymphPercent	CD8 Lymphocytes %																								
+VZ:CD8LymphAb	CD8 Lymphocytes Abs																								
+VZ:HBA1c	HBA1c																								
+VZ:HBA1C%	HBA1C%																								
+VZ:Glucose	Glucose Average (calculated)																								
+VZ:Rifampicin	Rifampicin Resistance																								
+VZ:GeneXpert	TB GeneXpert Test Result																								
+VZ:LiquidCulture	Liquid Culture Result(MGIT)																								
+VZ:SolidCulture	Solid Culture Result(7H11)																								
+VZ:SolidIncub	Solid Culture Incubation																								
+VZ:HIVElisa	HIV Elisa Result																								
+VZ:VL	HIV Viral Load Result																								
+VZ:MOLeftLungNormal	Medical Officer Left Lung Normal																								
+VZ:MOLeftLungConsolid	Medical Officer Left Lung Consolidation																								
+VZ:MOLeftLungCavitation	Medical Officer Left Lung Cavitation																								
+VZ:MOLeftLungNodules	Medical Officer Left Lung Nodules																								
+VZ:MOLeftLungMass	Medical Officer Left Lung Mass																								
+VZ:MOLeftLungReticular	Medical Officer Left Lung Reticular Opacities																								
+VZ:MOLeftLungFibrosis	Medical Officer Left Lung Fibrosis																								
+VZ:MOLeftLungCalcification	Medical Officer Left Lung calcification																								
+VZ:MOLeftLungPleuralThick	Medical Officer Left Lung Pleural Thickening																								
+VZ:MOLeftLungPleuralEffusion	Medical Officer Left Lung Pleural Effusion																								
+VZ:MOLeftLungNodeEnlarge	Medical Officer Left Lung Node Enlargement																								
+VZ:MOLeftLungOther	Medical Officer Left Lung Other																								
+VZ:MORightLungNormal	Medical Officer Right Lung Normal																								
+VZ:MORightLungConsolid	Medical Officer Right Lung Consolidation																								
+VZ:MORightLungCavitation	Medical Officer Right Lung Cavitation																								
+VZ:MORightLungNodules	Medical Officer Right Lung Nodules																								
+VZ:MORightLungMass	Medical Officer Right Lung Mass																								
+VZ:MORightLungReticular	Medical Officer Right Lung ReticularOpacities																								
+VZ:MORightLungFibrosis	Medical Officer Right Lung Fibrosis																								
+VZ:MORightLungCalcification	Medical Officer Right Lung Calcification																								
+VZ:MORightLungPleuralThick	Medical Officer Right Lung Pleural Thickening																								
+VZ:MORightLungPleuralEffusion	Medical Officer Right Lung Pleural Effusion																								
+VZ:MORightLungNodeEnlarge	Medical Officer Right Lung Node Enlargement																								
+VZ:MORightLungOther	Medical Officer Right Lung Other																								
+VZ:MOActiveTB	Medical Officer Diagnostic ActiveTB		diagnosis of tuberculosis																						
+VZ:MOOldTB	Medical Officer Diagnostic OldTB		diagnosis of tuberculosis																						
+VZ:MOProbableTB	Medical Officer Diagnostic ProbableTB		diagnosis of tuberculosis																						
+VZ:MOOtherInfection	Medical Officer Diagnostic Other Infection																								
+VZ:MOInflammatoryDisorder	Medical Officer Diagnostic Inflammatory Disorder																								
+VZ:MONeoplasm	Medical Officer Diagnostic Neoplasm																								
+VZ:MOTrauma	Medical Officer Diagnostic Trauma																								
+VZ:MOCongenitalAbnormality	Medical Officer Diagnostic CongenitalAbnormality																								
+VZ:MOCardiacDisorder	Medical Officer Diagnostic CardiacDisorder																								
+VZ:MOVascularDisorder	Medical Officer Diagnostic VascularDisorder																								

--- a/src/convert/vukuzazi.py
+++ b/src/convert/vukuzazi.py
@@ -34,8 +34,8 @@ def main():
     entities = []
     variables = pd.read_excel(xlsx, 'Variables')
     for idx, row in variables.iterrows():
-        local_id = str(row['VariableName'])
-        name = str(row['Description'])
+        local_id = str(row['VariableName']).strip()
+        name = str(row['Description']).strip()
         cat_id = int(row['CategoryId'])
         cat_string = catid_strings[cat_id]
         entities.append({'Short ID': 'VZ:' + local_id, 'Label': name, 'Value': cat_string})

--- a/src/json/generate_cohort_json.py
+++ b/src/json/generate_cohort_json.py
@@ -7,7 +7,10 @@ from argparse import ArgumentParser, FileType
 master_map = {}
 
 cohorts = {'Korean Genome and Epidemiology Study (KoGES)': 'build/mapping/gecko-koges.ttl',
-           'Golestan Cohort Study': 'build/mapping/gecko-gcs.ttl'}
+           'Golestan Cohort Study': 'build/mapping/gecko-gcs.ttl',
+           'Genomics England / 100,000 Genomes Project': 'build/mapping/genomics-england-gecko.ttl',
+           'SAPRIN (South African Population Research Infrastructure Network)': 'build/mapping/saprin-gecko.ttl',
+           'Africa Health Research Institute (AHRI) Population Cohort': 'build/mapping/vukuzazi-gecko.ttl'}
 
 ignore_variables = ['venous or arterial', 'fasting or non-fasting', 'DNA/Genotyping', 'WGS', 'WES', 'Sequence variants',
                     'Epigenetics', 'Metagenomics', 'Microbiome markers', 'RNAseq/gene expression', 'eQTL', 'other']


### PR DESCRIPTION
This includes mappings for Genomics England, Vukuzazi, and SAPRIN.

Vukuzazi did not appear in the member cohorts data, but it is a part of Africa Health Research Institute (AHRI - [see here](https://www.ahri.org/ahri-launches-ground-breaking-new-research-programme/)) so I used that for the Vukuzazi cohort data.

Mappings are currently incomplete for these three, there are just a few select categories added. The mappings will be completed in the Google sheet [here](https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4)

Cohort data is now located at [`data/cohort-data.json`](https://github.com/jamesaoverton/IHCC/blob/9a07f76727a12ff8c488f0fb2aae9fa0ed76e134/data/cohort-data.json). This does not include the available datatypes, which will be added when #41 is merged.