### PR TITLE
Add cohort-only view to browser mockup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ data/cohort-data.json: src/json/generate_cohort_json.py data/member_cohorts.csv 
 
 ### Browser
 
-DATA := build/gcs-data.json build/gecko-data.json build/genomics-england-data.json build/koges-data.json build/saprin-data.json build/vukuzazi-data.json
+DATA := build/gcs-data.json build/gecko-data.json build/genomics-england-data.json build/koges-data.json build/saprin-data.json build/vukuzazi-data.json build/cohorts.json
 
 build/%-data.json: build/%.owl | build/robot.jar
 	$(ROBOT) export \
@@ -319,6 +319,9 @@ build/%-data.json: build/%.owl | build/robot.jar
 	--header "ID|LABEL|definition|question description|value|see also|subclasses" \
 	--sort "LABEL" \
 	--export $@
+
+build/cohorts.json: data/cohort-data.json
+	cp $< $@
 
 # GECKO without OBO terms = CINECA
 # This is used to drive aggregations
@@ -338,7 +341,14 @@ cohorts: $(COHORT_PAGES)
 $(COHORT_PAGES): src/create_cohort_html.py data/cohort-data.json data/metadata.json src/cohort.html.jinja2 build/cohorts
 	python3 $^
 
-BROWSER := build/index.html build/cineca.json build/koges-mapping.json build/gcs-mapping.json cohorts $(DATA)
+BROWSER := build/index.html \
+build/cineca.json \
+build/koges-mapping.json \
+build/gcs-mapping.json \
+build/genomics-england-mapping.json \
+build/vukuzazi-mapping.json \
+build/saprin-mapping.json \
+cohorts $(DATA)
 browser: $(BROWSER)
 
 serve: $(BROWSER)

--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ build/index.html: src/index.html | build
 
 # Top-level cohort data as HTML pages 
 
-COHORT_PAGES := build/cohorts/koges.html build/cohorts/gcs.html
+COHORT_PAGES := build/cohorts/koges.html build/cohorts/gcs.html build/cohorts/genomics-england.html build/cohorts/vukuzazi.html build/cohorts/saprin.html
 
 cohorts: $(COHORT_PAGES)
 
@@ -379,5 +379,5 @@ all: build/gcs.html build/gcs-tree.html
 all: build/koges.html build/koges-tree.html
 all: build/saprin.html build/saprin-tree.html
 all: build/vukuzazi.html build/vukuzazi-tree.html
-all: build/mapping/data.json
+all: data/cohort-data.json
 all: $(BROWSER)

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -1,5 +1,6 @@
 [
   {
+    "prefix": "KoGES",
     "cohort_name": "Korean Genome and Epidemiology Study (KoGES)",
     "countries": [
       "South Korea",
@@ -52,6 +53,7 @@
     }
   },
   {
+    "prefix": "GCS",
     "cohort_name": "Golestan Cohort Study",
     "countries": [
       "Iran"
@@ -76,6 +78,7 @@
     ]
   },
   {
+    "prefix": "GE",
     "cohort_name": "Genomics England / 100,000 Genomes Project",
     "countries": [
       "England"
@@ -100,6 +103,7 @@
     }
   },
   {
+    "prefix": "SAPRIN",
     "cohort_name": "SAPRIN (South African Population Research Infrastructure Network)",
     "countries": [
       "South Africa"
@@ -123,6 +127,7 @@
     }
   },
   {
+    "prefix": "VZ",
     "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
     "countries": [
       "South Africa"

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -8,5 +8,20 @@
 		"id": "KoGES",
 		"data_dictionary": "https://drive.google.com/file/d/1Hh_cG9HcZWXs70FEun8iDZZbt0H_J1oq/view",
 		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=737702084"
+	},
+	"Genomics England / 100,000 Genomes Project": {
+		"id": "Genomics England",
+		"data_dictionary": "https://cnfl.extge.co.uk/pages/viewpage.action?pageId=113189195",
+		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=888808694"
+	},
+	"SAPRIN (South African Population Research Infrastructure Network)": {
+		"id": "SAPRIN",
+		"data_dictionary": "https://drive.google.com/file/d/1u1sXEAAU7N_n2-WqfF6lMJozVVQSI0EU",
+		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=2135840437"
+	},
+	"Africa Health Research Institute (AHRI) Population Cohort": {
+		"id": "Vukuzazi",
+		"data_dictionary": "https://drive.google.com/file/d/1YpwjiYDos5ZkXMQR6wG4Qug7sMmKB5xC/view",
+		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=817993717"
 	}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -89,6 +89,12 @@ td, th {
 
 <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 <script>
+var cohort_pages = {'KoGES': 'cohorts/koges.html',
+                    'VZ': 'cohorts/vukuzazi.html',
+                    'GE': 'cohorts/genomics-england.html',
+                    'GCS': 'cohorts/gcs.html',
+                    'SAPRIN': 'cohorts/saprin.html'}
+
 // Create map of term ID -> label
 function createIDMap(data) {
     let map = new Map();
@@ -194,15 +200,11 @@ function addCohortSearchResults(tbody, data) {
 
         var nameCell = document.createElement("td");
         nameCell.setAttribute("class", "name-col");
-    
-        if (node.hasOwnProperty("website") && node.website != "") {
-            var a = document.createElement("a");
-            a.setAttribute("href", node.website);
-            a.innerHTML = node.cohort_name;
-            nameCell.appendChild(a);
-        } else {
-            nameCell.innerHTML = node.cohort_name;
-        }
+        var a = document.createElement("a");
+        var cohort_page = cohort_pages[node.prefix];
+        a.setAttribute("href", cohort_page);
+        a.innerHTML = node.cohort_name;
+        nameCell.appendChild(a);
 
         var piCell = document.createElement("td");
         piCell.setAttribute("class", "pi-col");

--- a/src/index.html
+++ b/src/index.html
@@ -23,7 +23,7 @@ td, th {
     max-width: 80px !important;
 }
 
-.name-col {
+.name-col, .country-col, .pi-col, .dt-col {
     max-width: 120px !important;
 }
 
@@ -45,21 +45,31 @@ td, th {
 <body>
     <div class="container-fluid" style="margin-top: 10px;">
         <div class="row">
-            <div class="col-3"><h1>IHCC Browser Mockup</h1></div>
-            <div class="col">
+            <div class="col-3"><h2>IHCC Browser Mockup</h2></div>
+            <div class="col-3">
                 <div class="search" style="margin-bottom: 10px; margin-top: 10px;">
-                        <form class="form-inline">
-                            <div class="form-group mb-2">
-                                <input type="text" id="searchBox" class="form-control" placeholder="Search results...">
-                            </div>
-                            <div class="form-group mb-2" style="margin-left:10px;">
-                                <button type="button" id="searchBtn" class="btn btn-primary">Search</button>
-                            </div>
-                            <div class="form-group mb-2" style="margin-left:10px;">
-                                <button type="button" id="clearBtn" class="btn btn-primary">Clear</button>
-                            </div>
-                        </form>
-                    </div>
+                    <form class="form-inline">
+                        <div class="form-group mb-2">
+                            <input type="text" id="searchBox" class="form-control" placeholder="Search results...">
+                        </div>
+                        <div class="form-group mb-2" style="margin-left:10px;">
+                            <button type="button" id="searchBtn" class="btn btn-primary">Search</button>
+                        </div>
+                        <div class="form-group mb-2" style="margin-left:10px;">
+                            <button type="button" id="clearBtn" class="btn btn-primary">Clear</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <div class="col-2">
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="radios" id="radios1" value="allFields" checked>
+                    <label class="form-check-label" for="allFields">All fields</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="radios" id="radios2" value="cohortsOnly">
+                    <label class="form-check-label" for="cohortsOnly">Cohorts only</label>
+                </div>
             </div>
         </div>
         <div class="row">
@@ -70,7 +80,8 @@ td, th {
             </div>
             <div class="col-10" style="flex: 1 1 0%; position: relative; outline: none;">
                 <div class="search-results-wrapper">
-                    <div class="search-results"></div>
+                    <div class="search-results" id="allFields"></div>
+                    <div class="search-results" id="cohortsOnly"></div>
                 </div>
             </div>
         </div>
@@ -174,6 +185,50 @@ function createAggregations(data, gecko) {
     aggs.appendChild(div);
 }
 
+function addCohortSearchResults(tbody, data) {
+    for (var i = 0; i < data.length; i++) {
+        var node = data[i];
+        var row = document.createElement("tr");
+        row.setAttribute("class", "cohort-row");
+        row.setAttribute("id", node.prefix);
+
+        var nameCell = document.createElement("td");
+        nameCell.setAttribute("class", "name-col");
+    
+        if (node.hasOwnProperty("website") && node.website != "") {
+            var a = document.createElement("a");
+            a.setAttribute("href", node.website);
+            a.innerHTML = node.cohort_name;
+            nameCell.appendChild(a);
+        } else {
+            nameCell.innerHTML = node.cohort_name;
+        }
+
+        var piCell = document.createElement("td");
+        piCell.setAttribute("class", "pi-col");
+        piCell.innerHTML = node.pi_lead;
+
+        var countries = node.countries.join(', ');
+        var countryCell = document.createElement("td");
+        countryCell.setAttribute("class", "country-col");
+        countryCell.innerHTML = countries;
+
+        var datatypes = node.datatypes.join(', ');
+        var dtCell = document.createElement("td");
+        dtCell.setAttribute("class", "dt-col");
+        dtCell.innerHTML = datatypes;
+
+        // Add to row element
+        row.appendChild(nameCell);
+        row.appendChild(piCell);
+        row.appendChild(countryCell);
+        row.appendChild(dtCell);
+
+        // Add row to table element
+        tbody.appendChild(row);
+    }
+}
+
 // Add dataset to search results table
 function addSearchResults(tbody, source, data) {
     for (var i = 0; i < data.length; i++) {
@@ -271,9 +326,60 @@ function addSearchResults(tbody, source, data) {
     }
 }
 
+function createCohortSearchResults(cohorts) {
+    var res = document.getElementById("cohortsOnly");
+
+    var wrapper = document.createElement("div");
+
+    var table = document.createElement("table");
+    table.setAttribute("class", "table");
+
+    var thead = document.createElement("thead");
+
+    // Name column
+    var nameHeader = document.createElement("th");
+    nameHeader.setAttribute("scope", "col");
+    nameHeader.setAttribute("class", "name-col");
+    nameHeader.innerHTML = "Cohort Name";
+    thead.appendChild(nameHeader);
+
+    // PI Lead
+    var piHeader = document.createElement("th");
+    piHeader.setAttribute("scope", "col");
+    piHeader.setAttribute("class", "pi-col");
+    piHeader.innerHTML = "PI Leads";
+    thead.appendChild(piHeader);
+
+    // Countries
+    var countryHeader = document.createElement("th");
+    countryHeader.setAttribute("scope", "col");
+    countryHeader.setAttribute("class", "country-col");
+    countryHeader.innerHTML = "Countries";
+    thead.appendChild(countryHeader);
+
+    // Datatypes
+    var dtHeader = document.createElement("th");
+    dtHeader.setAttribute("scope", "col");
+    dtHeader.setAttribute("class", "dt-col");
+    dtHeader.innerHTML = "Datatypes";
+    thead.appendChild(dtHeader);
+
+    // Add header to table
+    table.appendChild(thead);
+
+    // Create the table body
+    var tbody = document.createElement("tbody");
+
+    addCohortSearchResults(tbody, cohorts);
+
+    table.appendChild(tbody);
+    wrapper.appendChild(table);
+    res.appendChild(wrapper);
+}
+
 // Create search results table
 function createSearchResults(dataSets) {
-    var res = document.getElementsByClassName("search-results")[0];
+    var res = document.getElementById("allFields");
 
     var wrapper = document.createElement("div");
 
@@ -341,25 +447,64 @@ function createSearchResults(dataSets) {
     res.appendChild(wrapper);
 }
 
+var allCohortsShown = true;
+
 // Filter table based on check box selection
+// For cohort view, the filtered result is an intersection
+// For all fields view, the filtered result is a union
 function filterTable(catMap, checked) {
     if (checked.length == 0) {
         // Nothing checked, show all
-        $('.search-row').show();
+        if (allCohortsShown) {
+            $('.search-row').show();
+        } else {
+            $('.cohort-row').show();
+        }
     } else {
-        // Hide all rows
-        $('.search-row').hide();
+        if (allCohortsShown) {
+            // Hide all rows
+            $('.search-row').hide();
 
-        // Get the IDs that match each checked category and show them
-        var len = checked.length;
-        for (i = 0; i < len; i++) {
-            var ids = catMap[checked[i]];
-            if (ids === undefined) {
-                continue;
+            // Get the IDs that match each checked category and show them
+            var len = checked.length;
+            for (i = 0; i < len; i++) {
+                var ids = catMap[checked[i]];
+                if (ids === undefined) {
+                    continue;
+                }
+                var idLen = ids.length;
+                for (k = 0; k < idLen; k++) {
+                    document.getElementById(ids[k]).style.display = "";
+                }
             }
-            var idLen = ids.length;
-            for (k = 0; k < idLen; k++) {
-                document.getElementById(ids[k]).style.display = "";
+        } else {
+            // Hide all rows
+            $('.cohort-row').hide();
+
+            // Get the cohort IDs that match ALL checked categories
+            var len = checked.length;
+            var keep = [];
+            for (i = 0; i < len; i++) {
+                var ids = catMap[checked[i]];
+                if (ids === undefined) {
+                    continue;
+                }
+                var idLen = ids.length;
+                var prefixes = [];
+                for (k = 0; k < idLen; k++) {
+                    prefix = ids[k].split(':')[0];
+                    prefixes.push(prefix);
+                }
+                var unique = [...new Set(prefixes)];
+                if (i == 0) {
+                    keep = unique;
+                } else {
+                    keep = keep.filter(value => unique.includes(value));
+                }
+            }
+            var uniqueKeep = [...new Set(keep)];
+            for (i = 0; i < uniqueKeep.length; i++) {
+                document.getElementById(uniqueKeep[i]).style.display = "";
             }
         }
     }
@@ -427,9 +572,9 @@ function get_json(path) {
 var gcs = get_json('./gcs-data.json');
 var koges = get_json('./koges-data.json');
 // var gecko = get_json('./gecko-data.json');
-// var genomicsEngland = get_json('./genomics-england-data.json');
-// var saprin = get_json('./saprin-data.json');
-// var vukuzazi = get_json('./vukuzazi-data.json');
+var genomicsEngland = get_json('./genomics-england-data.json');
+var saprin = get_json('./saprin-data.json');
+var vukuzazi = get_json('./vukuzazi-data.json');
 
 // Get the JSON for the aggregations
 var gecko = get_json('./gecko-data.json');
@@ -437,7 +582,10 @@ var gecko = get_json('./gecko-data.json');
 // Get the JSON that maps aggregation cats -> search results
 var kogesMap = get_json('./koges-mapping.json');
 var gcsMap = get_json('./gcs-mapping.json');
-var maps = [kogesMap, gcsMap];
+var geMap = get_json('./genomics-england-mapping.json');
+var saprinMap = get_json('./saprin-mapping.json');
+var vzMap = get_json('./vukuzazi-mapping.json');
+var maps = [kogesMap, gcsMap, geMap, saprinMap, vzMap];
 
 // Merge the mappings
 var catMap = new Map();
@@ -463,9 +611,9 @@ var allDataSets = new Map();
 allDataSets.set("GCS", gcs);
 allDataSets.set("KoGES", koges);
 // allDataSets.set("CINECA", gecko);
-// allDataSets.set("Genomics England", genomicsEngland);
-// allDataSets.set("SAPRIN", saprin);
-// allDataSets.set("Vukuzazi", vukuzazi);
+allDataSets.set("Genomics England", genomicsEngland);
+allDataSets.set("SAPRIN", saprin);
+allDataSets.set("Vukuzazi", vukuzazi);
 
 // Create the tables
 // Use the top-level CINECA structure to drive aggregations
@@ -473,6 +621,9 @@ allDataSets.set("KoGES", koges);
 var cineca = get_json('./cineca.json');
 createAggregations(cineca, gecko);
 createSearchResults(allDataSets);
+
+var cohorts = get_json('./cohorts.json');
+createCohortSearchResults(cohorts);
 
 // Event listener for check box selections
 document.addEventListener("DOMContentLoaded", function (event) {
@@ -489,6 +640,17 @@ document.addEventListener("DOMContentLoaded", function (event) {
             }
             filterTable(catMap, checked);
     });
+});
+
+// Start with all fields
+var resTables = $('.search-results');
+resTables.hide();
+$('#allFields').show();
+
+$('input[name="radios"]').on('change', function() {
+    allCohortsShown = !allCohortsShown;
+    resTables.hide();
+    $('#' + $(this).val()).show();
 });
 
 $('#searchBtn').click(function() {

--- a/src/json/generate_cohort_json.py
+++ b/src/json/generate_cohort_json.py
@@ -6,11 +6,17 @@ from argparse import ArgumentParser, FileType
 
 master_map = {}
 
-cohorts = {'Korean Genome and Epidemiology Study (KoGES)': 'build/mapping/gecko-koges.ttl',
-           'Golestan Cohort Study': 'build/mapping/gecko-gcs.ttl',
-           'Genomics England / 100,000 Genomes Project': 'build/mapping/genomics-england-gecko.ttl',
-           'SAPRIN (South African Population Research Infrastructure Network)': 'build/mapping/saprin-gecko.ttl',
-           'Africa Health Research Institute (AHRI) Population Cohort': 'build/mapping/vukuzazi-gecko.ttl'}
+ttl_files = {'KoGES': 'build/mapping/gecko-koges.ttl',
+             'GCS': 'build/mapping/gecko-gcs.ttl',
+             'GE': 'build/mapping/genomics-england-gecko.ttl',
+             'SAPRIN': 'build/mapping/saprin-gecko.ttl',
+             'VZ': 'build/mapping/vukuzazi-gecko.ttl'}
+
+names = {'KoGES': 'Korean Genome and Epidemiology Study (KoGES)',
+            'GCS': 'Golestan Cohort Study',
+            'GE': 'Genomics England / 100,000 Genomes Project',
+            'SAPRIN': 'SAPRIN (South African Population Research Infrastructure Network)',
+            'VZ': 'Africa Health Research Institute (AHRI) Population Cohort'}
 
 ignore_variables = ['venous or arterial', 'fasting or non-fasting', 'DNA/Genotyping', 'WGS', 'WES', 'Sequence variants',
                     'Epigenetics', 'Metagenomics', 'Microbiome markers', 'RNAseq/gene expression', 'eQTL', 'other']
@@ -55,14 +61,16 @@ def main():
                                'datatypes': datatypes}
 
     all_data = []
-    for cohort_name, file_name in cohorts.items():
+    for prefix, cohort_name in names.items():
+        file_name = ttl_files[prefix]
         gin = rdflib.Graph()
         gin.parse(file_name, format='turtle')
         child_to_parent = get_children(gin, 'http://example.com/GECKO_9999998')
         master_map = {}
         data = get_data(child_to_parent)
         if cohort_name in cohort_data:
-            this_cohort = cohort_data[cohort_name]
+            this_cohort = {'prefix': prefix}
+            this_cohort.update(cohort_data[cohort_name])
             this_cohort.update(data)
             all_data.append(this_cohort)
 

--- a/src/queries/get-cineca-genomics-england.rq
+++ b/src/queries/get-cineca-genomics-england.rq
@@ -1,0 +1,7 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?s ?cineca WHERE {
+    ?s rdfs:subClassOf* ?cineca .
+    FILTER(STRSTARTS(STR(?cineca), "http://example.com/GECKO_0"))
+    FILTER(STRSTARTS(STR(?s), "http://example.com/GE_"))
+}

--- a/src/queries/get-cineca-saprin.rq
+++ b/src/queries/get-cineca-saprin.rq
@@ -1,0 +1,7 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?s ?cineca WHERE {
+    ?s rdfs:subClassOf* ?cineca .
+    FILTER(STRSTARTS(STR(?cineca), "http://example.com/GECKO_0"))
+    FILTER(STRSTARTS(STR(?s), "http://example.com/SAPRIN_"))
+}

--- a/src/queries/get-cineca-vukuzazi.rq
+++ b/src/queries/get-cineca-vukuzazi.rq
@@ -1,0 +1,7 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?s ?cineca WHERE {
+    ?s rdfs:subClassOf* ?cineca .
+    FILTER(STRSTARTS(STR(?cineca), "http://example.com/GECKO_0"))
+    FILTER(STRSTARTS(STR(?s), "http://example.com/VZ_"))
+}


### PR DESCRIPTION
Resolves #36

Note that this adds a `prefix` field to the cohort data. If this is an issue, I can do it a different way, but this was the easiest way to get IDs to filter the cohort-only view.

The filtering for cohorts-only is an intersection. So if you select "blood" and "urine", it will only display cohorts that collect both blood and urine data.

The filtering for all fields is a union. If you select "blood" and "urine", it will display all fields from all cohorts related to blood and urine.