### PR TITLE
Data update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,14 @@ build/%-mapping.json: src/json/generate_mapping_json.py build/mapping/%-mapping.
 data/cohort-data.json: src/json/generate_cohort_json.py data/member_cohorts.csv data/metadata.json src/json/cineca_structure.json | $(MAPPINGS)
 	python3 $^ $@
 
+# Real cohort data + randomly-generated cohort data
+
+data/full-cohort-data.json: data/cohort-data.json data/random-data.json
+	$(eval REAL_DATA := $(shell sed '$$d' $< | sed '$$d' | sed -e 's|"|\\"|g' | awk '{printf "%s\\n", $$0}'))
+	$(eval FAKE_DATA := $(shell sed '1,2d' $(word 2,$^) | sed -e 's|"|\\"|g' | awk '{printf "%s\\n", $$0}'))
+	@echo -e "$(REAL_DATA)  }," >> $@
+	@echo -e "  {\n    $(FAKE_DATA)" >> $@
+
 
 ### Browser
 

--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ data/full-cohort-data.json: data/cohort-data.json data/random-data.json
 
 ### Browser
 
-DATA := build/gcs-data.json build/gecko-data.json build/genomics-england-data.json build/koges-data.json build/saprin-data.json build/vukuzazi-data.json build/cohorts.json
+DATA := build/gcs-data.json build/gecko-data.json build/genomics-england-data.json build/koges-data.json build/saprin-data.json build/vukuzazi-data.json build/cohorts.json build/metadata.json
 
 build/%-data.json: build/%.owl | build/robot.jar
 	$(ROBOT) export \
@@ -328,7 +328,10 @@ build/%-data.json: build/%.owl | build/robot.jar
 	--sort "LABEL" \
 	--export $@
 
-build/cohorts.json: data/cohort-data.json
+build/cohorts.json: data/full-cohort-data.json
+	cp $< $@
+
+build/metadata.json: data/metadata.json
 	cp $< $@
 
 # GECKO without OBO terms = CINECA

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ build/%-mapping.json: src/json/generate_mapping_json.py build/mapping/%-mapping.
 
 # Top-level cohort data
 
-data/cohort-data.json: src/json/generate_cohort_json.py data/member_cohorts.csv | $(MAPPINGS)
+data/cohort-data.json: src/json/generate_cohort_json.py data/member_cohorts.csv data/metadata.json src/json/cineca_structure.json | $(MAPPINGS)
 	python3 $^ $@
 
 

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -12,28 +12,28 @@
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic cohort attributes": {
-      "demographic data": null
+    "basic_cohort_attributes": {
+      "demographic_data": null
     },
     "biosample": {
-      "sample type": [
+      "sample_type": [
         "blood"
       ]
     },
-    "questionnaire/survey data": {
-      "lifestyle and behaviours": [
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
         "tobacco"
       ],
-      "physiological measurements": {
+      "physiological_measurements": {
         "anthropometry": null,
-        "cirulation and respiration": [
-          "blood pressure"
+        "cirulation_and_respiration": [
+          "blood_pressure"
         ]
       },
       "general_variables": [
-        "signs and symptoms"
+        "signs_and_symptoms"
       ],
-      "socio-demographic and economic characteristics": [
+      "socio_demographic_and_economic_characteristics": [
         "residence"
       ]
     }
@@ -56,22 +56,22 @@
       "phenotypic_clinical_data": true
     },
     "biosample": {
-      "sample type": [
+      "sample_type": [
         "urine"
       ]
     },
-    "laboratory measures": {
+    "laboratory_measures": {
       "microbiology": [
-        "microbial data"
+        "microbial_data"
       ]
     },
-    "questionnaire/survey data": {
-      "physiological measurements": {
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
         "anthropometry": [
           "weight"
         ],
-        "cirulation and respiration": [
-          "heart rate"
+        "cirulation_and_respiration": [
+          "heart_rate"
         ]
       }
     }
@@ -89,13 +89,13 @@
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "questionnaire/survey data": {
-      "physiological measurements": {
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
         "anthropometry": [
           "weight"
         ]
       },
-      "socio-demographic and economic characteristics": [
+      "socio_demographic_and_economic_characteristics": [
         "gender"
       ]
     }
@@ -113,8 +113,8 @@
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "questionnaire/survey data": {
-      "socio-demographic and economic characteristics": [
+    "questionnaire_survey_data": {
+      "socio_demographic_and_economic_characteristics": [
         "residence"
       ]
     }
@@ -133,24 +133,24 @@
       "phenotypic_clinical_data": true
     },
     "biosample": {
-      "sample type": [
+      "sample_type": [
         "urine"
       ]
     },
-    "questionnaire/survey data": {
-      "lifestyle and behaviours": [
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
         "tobacco"
       ],
-      "physiological measurements": {
+      "physiological_measurements": {
         "anthropometry": [
           "weight"
         ],
-        "cirulation and respiration": [
-          "heart rate"
+        "cirulation_and_respiration": [
+          "heart_rate"
         ]
       },
       "general_variables": [
-        "signs and symptoms"
+        "signs_and_symptoms"
       ]
     }
   }

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -6,6 +6,9 @@
     ],
     "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
     "website": "https://dceg2.cancer.gov/gemshare/",
+    "current_enrollment": 50000,
+    "target_enrollment": null,
+    "enrollment_period": "2004:2008",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": true,
@@ -49,6 +52,9 @@
     ],
     "pi_lead": "Sung Soo Kim",
     "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264",
+    "current_enrollment": 235000,
+    "target_enrollment": null,
+    "enrollment_period": "2001:2013",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -83,6 +89,9 @@
     ],
     "pi_lead": "Mark Caulfield",
     "website": "https://www.genomicsengland.co.uk/",
+    "current_enrollment": 100000,
+    "target_enrollment": 500000,
+    "enrollment_period": "2013:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
@@ -107,6 +116,9 @@
     ],
     "pi_lead": "Kobus Herbst",
     "website": "http://saprin.mrc.ac.za/",
+    "current_enrollment": 350000,
+    "target_enrollment": 700000,
+    "enrollment_period": "1993:ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -126,6 +138,9 @@
     ],
     "pi_lead": "Deenan Pillay",
     "website": "https://www.ahri.org",
+    "current_enrollment": 130000,
+    "target_enrollment": 130000,
+    "enrollment_period": "2000:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,

--- a/data/cohort-data.json
+++ b/data/cohort-data.json
@@ -1,6 +1,44 @@
 [
   {
-    "prefix": "KoGES",
+    "cohort_name": "Golestan Cohort Study",
+    "countries": [
+      "Iran"
+    ],
+    "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
+    "website": "https://dceg2.cancer.gov/gemshare/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic cohort attributes": {
+      "demographic data": null
+    },
+    "biosample": {
+      "sample type": [
+        "blood"
+      ]
+    },
+    "questionnaire/survey data": {
+      "lifestyle and behaviours": [
+        "tobacco"
+      ],
+      "physiological measurements": {
+        "anthropometry": null,
+        "cirulation and respiration": [
+          "blood pressure"
+        ]
+      },
+      "general_variables": [
+        "signs and symptoms"
+      ],
+      "socio-demographic and economic characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
     "cohort_name": "Korean Genome and Epidemiology Study (KoGES)",
     "countries": [
       "South Korea",
@@ -11,15 +49,14 @@
     ],
     "pi_lead": "Sung Soo Kim",
     "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264",
-    "datatypes": [
-      "Genomic Data",
-      "Environmental Data",
-      "Biospecimens",
-      "Phenotypic/Clinical Data"
-    ],
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
     "biosample": {
       "sample type": [
-        "blood",
         "urine"
       ]
     },
@@ -29,71 +66,32 @@
       ]
     },
     "questionnaire/survey data": {
-      "lifestyle and behaviours": [
-        "alcohol",
-        "nutrition",
-        "sleep",
-        "tobacco"
-      ],
       "physiological measurements": {
         "anthropometry": [
-          "height",
           "weight"
         ],
-        "circulation and respiration": [
-          "blood pressure",
+        "cirulation and respiration": [
           "heart rate"
         ]
-      },
-      "socio-demographic and economic characteristics": [
-        "education",
-        "family and household structure",
-        "occupation"
-      ]
+      }
     }
   },
   {
-    "prefix": "GCS",
-    "cohort_name": "Golestan Cohort Study",
-    "countries": [
-      "Iran"
-    ],
-    "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
-    "website": "https://dceg2.cancer.gov/gemshare/",
-    "datatypes": [
-      "Environmental Data",
-      "Biospecimens",
-      "Phenotypic/Clinical Data"
-    ],
-    "basic cohort attributes": [
-      "demographic data"
-    ],
-    "biosample": {
-      "sample type": [
-        "blood"
-      ]
-    },
-    "questionnaire/survey data": [
-      "signs and symptoms"
-    ]
-  },
-  {
-    "prefix": "GE",
     "cohort_name": "Genomics England / 100,000 Genomes Project",
     "countries": [
       "England"
     ],
     "pi_lead": "Mark Caulfield",
     "website": "https://www.genomicsengland.co.uk/",
-    "datatypes": [
-      "Genomic Data",
-      "Biospecimens",
-      "Phenotypic/Clinical Data"
-    ],
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
     "questionnaire/survey data": {
       "physiological measurements": {
         "anthropometry": [
-          "height",
           "weight"
         ]
       },
@@ -103,50 +101,57 @@
     }
   },
   {
-    "prefix": "SAPRIN",
     "cohort_name": "SAPRIN (South African Population Research Infrastructure Network)",
     "countries": [
       "South Africa"
     ],
     "pi_lead": "Kobus Herbst",
     "website": "http://saprin.mrc.ac.za/",
-    "datatypes": [
-      "Biospecimens",
-      "Phenotypic/Clinical Data"
-    ],
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
     "questionnaire/survey data": {
       "socio-demographic and economic characteristics": [
-        "age/birthdate",
-        "biological sex",
-        "education",
-        "ethnicity/race",
-        "family and household structure",
-        "occupation",
         "residence"
       ]
     }
   },
   {
-    "prefix": "VZ",
     "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
     "countries": [
       "South Africa"
     ],
     "pi_lead": "Deenan Pillay",
     "website": "https://www.ahri.org",
-    "datatypes": [
-      "Genomic Data",
-      "Biospecimens",
-      "Phenotypic/Clinical Data"
-    ],
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
     "biosample": {
       "sample type": [
-        "blood",
         "urine"
       ]
     },
-    "questionnaire/survey data": [
-      "signs and symptoms"
-    ]
+    "questionnaire/survey data": {
+      "lifestyle and behaviours": [
+        "tobacco"
+      ],
+      "physiological measurements": {
+        "anthropometry": [
+          "weight"
+        ],
+        "cirulation and respiration": [
+          "heart rate"
+        ]
+      },
+      "general_variables": [
+        "signs and symptoms"
+      ]
+    }
   }
 ]

--- a/data/full-cohort-data.json
+++ b/data/full-cohort-data.json
@@ -1,0 +1,2837 @@
+[
+  {
+    "cohort_name": "Golestan Cohort Study",
+    "countries": [
+      "Iran"
+    ],
+    "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
+    "website": "https://dceg2.cancer.gov/gemshare/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": null
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "physiological_measurements": {
+        "anthropometry": null,
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Korean Genome and Epidemiology Study (KoGES)",
+    "countries": [
+      "South Korea",
+      "Vietnam",
+      "Cambodia",
+      "Japan",
+      "China"
+    ],
+    "pi_lead": "Sung Soo Kim",
+    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ],
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      }
+    }
+  },
+  {
+    "cohort_name": "Genomics England / 100,000 Genomes Project",
+    "countries": [
+      "England"
+    ],
+    "pi_lead": "Mark Caulfield",
+    "website": "https://www.genomicsengland.co.uk/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "SAPRIN (South African Population Research Infrastructure Network)",
+    "countries": [
+      "South Africa"
+    ],
+    "pi_lead": "Kobus Herbst",
+    "website": "http://saprin.mrc.ac.za/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "questionnaire_survey_data": {
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Africa Health Research Institute (AHRI) Population Cohort",
+    "countries": [
+      "South Africa"
+    ],
+    "pi_lead": "Deenan Pillay",
+    "website": "https://www.ahri.org",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ],
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ]
+    }
+  },
+  {
+    "cohort_name": "23andMe",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Joyce Tung",
+    "website": "https://research.23andme.com/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "45 and Up Study",
+    "countries": [
+      "Australia"
+    ],
+    "pi_lead": "Martin McNamara",
+    "website": "https://www.saxinstitute.org.au/our-work/45-up-study/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ],
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Apolipoprotein MORtality RISk study (AMORIS)",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Goran Walldius",
+    "website": "http://amoriscohort.imm.ki.se",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Biobank Japan",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Yoshinori Murakami",
+    "website": "https://biobankjp.org/english/index.html",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "Metagenomics"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "BioVU Vanderbilt",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Dan Roden",
+    "website": "https://victr.vanderbilt.edu/pub/biovu/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "Metagenomics"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Canadian Partnership for Tomorrow Project (CPTP)",
+    "countries": [
+      "Canada"
+    ],
+    "pi_lead": "Philip Awadalla",
+    "website": "http://www.partnershipfortomorrow.ca",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II (CPS-II)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": false,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II Nutrition Cohort",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Children's Hospital of Philadelphia (CHOP) Biorepository",
+    "countries": [
+      "USA",
+      "Europe",
+      "South America",
+      "Canada",
+      "Saudi Arabia",
+      "Australia"
+    ],
+    "pi_lead": "Hakon Hakonarson",
+    "website": "https://caglab.org/index.php/for-researchers/biorepository.html",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "China Kadoorie Biobank",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Zhengming Chen and Liming Li",
+    "website": "http://www.ckbiobank.org/site/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    }
+  },
+  {
+    "cohort_name": "China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Linxin Jiang",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      }
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Constances Project",
+    "countries": [
+      "France"
+    ],
+    "pi_lead": "Marie Zins",
+    "website": "http://www.constances.fr/index_EN.php",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Danish National Birth Cohort",
+    "countries": [
+      "Denmark"
+    ],
+    "pi_lead": "Mads Melbye",
+    "website": "dnbc.dk",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ],
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "East London Genes and Health",
+    "countries": [
+      "UK"
+    ],
+    "pi_lead": "David van Heel",
+    "website": "http://www.genesandhealth.org/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "ELSA-Brasil",
+    "countries": [
+      "Brazil: six cities"
+    ],
+    "pi_lead": "Paulo A. Lotufo",
+    "website": "www.elsa.org.br",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Environmental influences on Child Health Outcomes (ECHO) Cohort",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Matt Gillman",
+    "website": "https://www.nih.gov/echo",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "EPIC (European Prospective Investigation into Cancer, Chronic Diseases, Nutrition and Lifestyle)",
+    "countries": [
+      "UK",
+      "Italy",
+      "France",
+      "Germany",
+      "Norway",
+      "Netherlands",
+      "Denmark",
+      "Spain",
+      "Greece",
+      "Sweden"
+    ],
+    "pi_lead": "Elio Riboli, Paul Brennan, and Marc Gunter",
+    "website": "http://epic.iarc.fr/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ],
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "administration_method"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "EpiHealth",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Lars Lind and S\u221a\u2202lve Elmst\u221a\u2022lh",
+    "website": "https://www.epihealth.se/vad-ar-epihealth/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ],
+        "general_variables": [
+          "processing_method"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Estonian Genome Project",
+    "countries": [
+      "Estonia"
+    ],
+    "pi_lead": "Andres Metspalu",
+    "website": "www.biobank.ee",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Finnish Maternity Cohort Serum Bank",
+    "countries": [
+      "Finland"
+    ],
+    "pi_lead": "Helj\u221a\u00a7-Marja Surcel",
+    "website": "www.esis.fi",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": false
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Generations Study (GS)",
+    "countries": [
+      "England",
+      "Scotland",
+      "Wales",
+      "Northern Ireland",
+      "Isle of Man",
+      "Channel Islands"
+    ],
+    "pi_lead": "Anthony Swerdlow",
+    "website": "http://www.breakthroughgenerations.org.uk/home",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Healthy Nevada",
+    "countries": [
+      "US"
+    ],
+    "pi_lead": "Joe Grzymski",
+    "website": "Healthynv.org",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": false,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Israel Genome Project",
+    "countries": [
+      "Israel"
+    ],
+    "pi_lead": "Gad Rennert",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study (JPHC)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "http://epi.ncc.go.jp/en/jphc/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "https://epi.ncc.go.jp/jphcnext/en/index.html",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_disease"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Kaiser Permanente Research Program on Genes, Environment, and Health",
+    "countries": [
+      "USA; Northern California"
+    ],
+    "pi_lead": "Catherine Schaefer",
+    "website": "http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Korea Biobank Project",
+    "countries": [
+      "Republic of Korea"
+    ],
+    "pi_lead": "Jae-Pil Jeon and Changhoon Kim",
+    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      }
+    }
+  },
+  {
+    "cohort_name": "Korean Cancer Prevention Study (KCPS-II Biobank)",
+    "countries": [
+      "Korea"
+    ],
+    "pi_lead": "Sun Ha Jee",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Epigenetics"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ]
+    }
+  },
+  {
+    "cohort_name": "LifeGene (and sister cohort, EpiHealth)",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Nancy Pedersen",
+    "website": "https://www.lifegene.se/For-scientists/About-LifeGene/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging)",
+    "countries": [
+      "Europe (7)",
+      "Australia",
+      "USA"
+    ],
+    "pi_lead": "Terrence Simmons",
+    "website": "http://www.lifepathproject.eu/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "posology"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Malaysian Cohort",
+    "countries": [
+      "Malaysia"
+    ],
+    "pi_lead": "Rahman Jamal",
+    "website": "http://mycohort.gov.my/site/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Maule Cohort (MAUCO Study)",
+    "countries": [
+      "Chile"
+    ],
+    "pi_lead": "Catterina Ferreccio",
+    "website": "http://www.accdis.cl/eng/en/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Mexico City Prospective Study",
+    "countries": [
+      "Mexico"
+    ],
+    "pi_lead": "Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, and Roberto Tapia-Conyer",
+    "website": "https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Veteran Program",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Mike Gaziano",
+    "website": "http://www.research.va.gov/mvp/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Women Study",
+    "countries": [
+      "England",
+      "Scotland"
+    ],
+    "pi_lead": "Valerie Beral",
+    "website": "http://www.millionwomenstudy.org/introduction/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      }
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "Multiethnic Cohort Study (MEC, NCI)",
+    "countries": [
+      "USA (Hawaii; California)"
+    ],
+    "pi_lead": "Loic Le Marchand",
+    "website": "https://www.uhcancercenter.org/mec",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "MyCode Community Health Initiative",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "David H Ledbetter",
+    "website": "https://www.geisinger.org/mycode",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "Netherlands Twin Registry",
+    "countries": [
+      "Netherlands"
+    ],
+    "pi_lead": "Dorret Boomsma",
+    "website": "http://www.tweelingenregister.org/en/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ],
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Newfoundland 100K Genome Project / Sequence Bio",
+    "countries": [
+      "Canada (Province of Newfoundland and Labrador)"
+    ],
+    "pi_lead": "Michael Phillips",
+    "website": "https://www.sequencebio.com/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "NHS (Nurses' Health Study, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Meir Stampfer, Rulla Tamimi",
+    "website": "www.nurseshealthstudy.org",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "NHSII (Nurses' Health Study II, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Walter Willett, Heather Eliassen",
+    "website": "www.nurseshealthstudy.org",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ]
+    }
+  },
+  {
+    "cohort_name": "NICCC",
+    "countries": [
+      ""
+    ],
+    "pi_lead": "Rennert Gad",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "circulatory_system"
+      ],
+      "medication": [
+        "posology"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Northern Sweden Health and Disease Study",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Beatrice Melin",
+    "website": "http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Norwegian Family Based Life Course Study",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "\u221a\u00f2yvind N\u221a\u00b6ss",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "posology"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Norwegian Mother and Child Cohort Study (MoBa)",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "Per Magnus",
+    "website": "https://www.fhi.no/en/studies/moba/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Pakistan Genomic Resource (PGR)",
+    "countries": [
+      "Pakistan"
+    ],
+    "pi_lead": "Danish Salaheen",
+    "website": "https://www.cncdpk.com/page/Pakistan-Genomic-Resource-(PGR)",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": false,
+      "phenotypic_clinical_data": false
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "PERSIAN Cohort Study",
+    "countries": [
+      "Iran"
+    ],
+    "pi_lead": "Reza Malekzadeh,  Hossein Poustchi,  Farin Kamangar,  Arash Etemadi",
+    "website": "http://persiancohort.com",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ]
+    }
+  },
+  {
+    "cohort_name": "PLCO (Prostate, Lung, Colorectal and Ovarian Cancer Screening Trial, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Paul Pinsky and Neal Freedman",
+    "website": "http://prevention.cancer.gov/major-programs/prostate-lung-colorectal",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_disease"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "prescription"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Qatar Genome Project",
+    "countries": [
+      "Qatar"
+    ],
+    "pi_lead": "Hamdi Mbarek",
+    "website": "https://qatargenome.org.qa/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Saudi Human Genome Program",
+    "countries": [
+      "Saudi Arabia"
+    ],
+    "pi_lead": "Sultan AlSudiri and Malak Abedalthagafi",
+    "website": "http://shgp.kacst.edu.sa/site/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": false
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Saudi National Biobank",
+    "countries": [
+      "Saudi Arabia"
+    ],
+    "pi_lead": "Ada Al-Qunaibet",
+    "website": "http://www.ksau-hs.edu.sa/English/Research/Pages/KAIMRC.aspx",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ],
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Shanghai Men and Women's Health Study (2 cohorts)",
+    "countries": [
+      "Shanghai",
+      "China"
+    ],
+    "pi_lead": "Wei Zheng",
+    "website": "http://www.mc.vanderbilt.edu/swhs-smhs/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "posology"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Singapore National Precision Medicine Program",
+    "countries": [
+      "Singapore"
+    ],
+    "pi_lead": "Patrick Tan and E Shyong Tai",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "South(east) Asian Cohorts - NETWORK",
+    "countries": [
+      "Bangladesh",
+      "Malaysia",
+      "Sri Lanka"
+    ],
+    "pi_lead": "Rajiv Chowdhury",
+    "website": "http://www.phpc.cam.ac.uk/ceu/international-vascular-health/believe/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Taiwan Biobank",
+    "countries": [
+      "Taiwan"
+    ],
+    "pi_lead": "Te-Chang Lee and Chung-ke Chang",
+    "website": "https://www.twbiobank.org.tw/new_web/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "U.S. Precision Medicine Initiative / All of Us",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Stephanie Devaney",
+    "website": "https://allofus.nih.gov/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "DNA_Genotyping"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "UK Biobank",
+    "countries": [
+      "England",
+      "Scotland",
+      "Wales"
+    ],
+    "pi_lead": "Rory Collins",
+    "website": "http://www.ukbiobank.ac.uk/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ],
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UK Blood Donor Cohorts",
+    "countries": [
+      "UK"
+    ],
+    "pi_lead": "Emanuele Di Angelantonio and John Danesh",
+    "website": "http://www.intervalstudy.org.uk/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women's Cohort UKLWC",
+    "countries": [
+      "England",
+      "Wales",
+      "Northern Ireland"
+    ],
+    "pi_lead": "Usha Menon",
+    "website": "http://www.isrctn.com/ISRCTN22488978",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Vorarlberg Health Monitoring and Promotion Programme (VHM&PP)",
+    "countries": [
+      "Austria"
+    ],
+    "pi_lead": "Hans Concin, Gabriele Nagel, Hanno Ulmer",
+    "website": "http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "WHI (Women's Health Initiative)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Garnet Anderson",
+    "website": "https://deino.whiops.org/go/www.whi.org~ssl/SitePages/WHI%20Home.aspx",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  }
+]
+

--- a/data/full-cohort-data.json
+++ b/data/full-cohort-data.json
@@ -6,6 +6,9 @@
     ],
     "pi_lead": "Reza Malekzadeh, Christian Abnet, Paolo Boffetta, Paul Brennan, Farin Kamangar, Arash Etemadi",
     "website": "https://dceg2.cancer.gov/gemshare/",
+    "current_enrollment": 50000,
+    "target_enrollment": null,
+    "enrollment_period": "2004:2008",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": true,
@@ -49,6 +52,9 @@
     ],
     "pi_lead": "Sung Soo Kim",
     "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65199&menuIds=HOME004-MNU2261-MNU2262-MNU2263-MNU2264",
+    "current_enrollment": 235000,
+    "target_enrollment": null,
+    "enrollment_period": "2001:2013",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -83,6 +89,9 @@
     ],
     "pi_lead": "Mark Caulfield",
     "website": "https://www.genomicsengland.co.uk/",
+    "current_enrollment": 100000,
+    "target_enrollment": 500000,
+    "enrollment_period": "2013:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
@@ -107,6 +116,9 @@
     ],
     "pi_lead": "Kobus Herbst",
     "website": "http://saprin.mrc.ac.za/",
+    "current_enrollment": 350000,
+    "target_enrollment": 700000,
+    "enrollment_period": "1993:ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -126,6 +138,9 @@
     ],
     "pi_lead": "Deenan Pillay",
     "website": "https://www.ahri.org",
+    "current_enrollment": 130000,
+    "target_enrollment": 130000,
+    "enrollment_period": "2000:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
@@ -161,45 +176,33 @@
     ],
     "pi_lead": "Joyce Tung",
     "website": "https://research.23andme.com/",
+    "current_enrollment": 6800000,
+    "target_enrollment": null,
+    "enrollment_period": "2007:Ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "timeline"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
     "laboratory_measures": {
       "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
         "data_type": [
-          "Sequence_variants"
+          "WGS"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "digestive_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "blood_pressure"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
+      "medication": [
+        "drug_responses"
       ]
-    }
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
   },
   {
     "cohort_name": "45 and Up Study",
@@ -208,18 +211,18 @@
     ],
     "pi_lead": "Martin McNamara",
     "website": "https://www.saxinstitute.org.au/our-work/45-up-study/",
+    "current_enrollment": 267153,
+    "target_enrollment": null,
+    "enrollment_period": "2006:2009",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "biosample": {
-      "sample_type": [
-        "saliva"
-      ],
+    "basic_cohort_attributes": {
       "general_variables": [
-        "storage_method"
+        "aims_and_objectives"
       ]
     },
     "laboratory_measures": {
@@ -231,15 +234,24 @@
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "nervous_system"
+        "digestive_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
       ],
       "lifestyle_and_behaviours": [
         "sleep"
       ],
+      "medication": [
+        "prescription"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "genealogy"
+        "education"
       ]
-    }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
   },
   {
     "cohort_name": "Apolipoprotein MORtality RISk study (AMORIS)",
@@ -248,89 +260,12 @@
     ],
     "pi_lead": "Goran Walldius",
     "website": "http://amoriscohort.imm.ki.se",
+    "current_enrollment": 812073,
+    "target_enrollment": null,
+    "enrollment_period": "1985:1996",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "microbiology": [
-        "biosample_source_anatomical_location"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Biobank Japan",
-    "countries": [
-      "Japan"
-    ],
-    "pi_lead": "Yoshinori Murakami",
-    "website": "https://biobankjp.org/english/index.html",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_medication"
-        ],
-        "data_type": [
-          "Metagenomics"
-        ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "BioVU Vanderbilt",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Dan Roden",
-    "website": "https://victr.vanderbilt.edu/pub/biovu/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
@@ -342,58 +277,10 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
+          "associated_phenotype"
         ],
         "data_type": [
           "Metagenomics"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "medication": [
-        "prescription"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Canadian Partnership for Tomorrow Project (CPTP)",
-    "countries": [
-      "Canada"
-    ],
-    "pi_lead": "Philip Awadalla",
-    "website": "http://www.partnershipfortomorrow.ca",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "genders_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
         ]
       },
       "microbiology": [
@@ -401,70 +288,27 @@
       ]
     },
     "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
       "lifestyle_and_behaviours": [
-        "nutrition"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
+        "sleep"
       ]
     },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
+    "survey_administration": [
+      "unique_identifiers"
     ]
   },
   {
-    "cohort_name": "Cancer Prevention Study II (CPS-II)",
+    "cohort_name": "Biobank Japan",
     "countries": [
-      "USA"
+      "Japan"
     ],
-    "pi_lead": "Susan Gapstur",
-    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": false,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "data_collection_events"
-      ],
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ],
-        "data_type": [
-          "RNAseq_gene_expression"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "nervous_system"
-      ],
-      "medication": [
-        "prescription"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "gender"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Cancer Prevention Study II Nutrition Cohort",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Susan Gapstur",
-    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study",
+    "pi_lead": "Yoshinori Murakami",
+    "website": "https://biobankjp.org/english/index.html",
+    "current_enrollment": 270000,
+    "target_enrollment": 270000,
+    "enrollment_period": "2003:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -475,21 +319,69 @@
       "genomics": {
         "general_variables": [
           "sample_size"
-        ],
-        "data_type": [
-          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "BioVU Vanderbilt",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Dan Roden",
+    "website": "https://victr.vanderbilt.edu/pub/biovu/",
+    "current_enrollment": 244000,
+    "target_enrollment": null,
+    "enrollment_period": "2007:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ],
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
         ]
       }
     },
     "questionnaire_survey_data": {
       "lifestyle_and_behaviours": [
-        "sleep"
+        "nutrition"
       ],
       "medication": [
-        "drug_responses"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
+        "prescription"
       ],
       "physiological_measurements": {
         "anthropometry": [
@@ -497,11 +389,150 @@
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Canadian Partnership for Tomorrow Project (CPTP)",
+    "countries": [
+      "Canada"
+    ],
+    "pi_lead": "Philip Awadalla",
+    "website": "http://www.partnershipfortomorrow.ca",
+    "current_enrollment": 315000,
+    "target_enrollment": null,
+    "enrollment_period": "2008:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ],
+      "demographic_data": [
+        "age_range"
       ]
     },
-    "survey_administration": [
-      "unique_identifiers"
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "circulatory_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II (CPS-II)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index",
+    "current_enrollment": 1185106,
+    "target_enrollment": null,
+    "enrollment_period": "1982:1983",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": false,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "Epigenetics"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II Nutrition Cohort",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study",
+    "current_enrollment": 184194,
+    "target_enrollment": null,
+    "enrollment_period": "1992:1993",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
     ]
   },
   {
@@ -516,8 +547,108 @@
     ],
     "pi_lead": "Hakon Hakonarson",
     "website": "https://caglab.org/index.php/for-researchers/biorepository.html",
+    "current_enrollment": 500000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "2006:ongoing",
     "available_data_types": {
       "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "China Kadoorie Biobank",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Zhengming Chen and Liming Li",
+    "website": "http://www.ckbiobank.org/site/",
+    "current_enrollment": 512891,
+    "target_enrollment": null,
+    "enrollment_period": "2004:2008",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Linxin Jiang",
+    "website": "",
+    "current_enrollment": 2000000,
+    "target_enrollment": 4000000,
+    "enrollment_period": "2014:ongoing",
+    "available_data_types": {
+      "genomic_data": false,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
@@ -533,98 +664,16 @@
     "laboratory_measures": {
       "genomics": {
         "data_type": [
-          "eQTL"
+          "WGS"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological"
+        "digestive_system"
       ],
       "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      }
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "China Kadoorie Biobank",
-    "countries": [
-      "China"
-    ],
-    "pi_lead": "Zhengming Chen and Liming Li",
-    "website": "http://www.ckbiobank.org/site/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
-        ],
-        "data_type": [
-          "WES"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
-      ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "blood_pressure"
-        ]
-      }
-    }
-  },
-  {
-    "cohort_name": "China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project",
-    "countries": [
-      "China"
-    ],
-    "pi_lead": "Linxin Jiang",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ],
-        "data_type": [
-          "Sequence_variants"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
+        "sleep"
       ],
       "physiological_measurements": {
         "anthropometry": [
@@ -643,40 +692,49 @@
     ],
     "pi_lead": "Marie Zins",
     "website": "http://www.constances.fr/index_EN.php",
+    "current_enrollment": 210000,
+    "target_enrollment": null,
+    "enrollment_period": "2012:2019",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "biosample": {
-      "sample_type": [
-        "urine"
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "data_type": [
-          "WGS"
+        "general_variables": [
+          "sample_size"
         ]
       }
     },
     "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
       "lifestyle_and_behaviours": [
-        "alcohol"
+        "tobacco"
+      ],
+      "medication": [
+        "prescription"
       ],
       "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ],
         "cirulation_and_respiration": [
           "blood_pressure"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "residence"
+        "birthplace"
       ]
-    },
-    "survey_administration": [
-      "date_and_time_related_information"
-    ]
+    }
   },
   {
     "cohort_name": "Danish National Birth Cohort",
@@ -685,6 +743,9 @@
     ],
     "pi_lead": "Mads Melbye",
     "website": "dnbc.dk",
+    "current_enrollment": 198028,
+    "target_enrollment": null,
+    "enrollment_period": "1998:2002",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -693,30 +754,36 @@
     },
     "basic_cohort_attributes": {
       "demographic_data": [
-        "age_range"
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "processing_method"
+          "available_data_formats"
         ],
         "data_type": [
-          "Sequence_variants"
+          "DNA_Genotyping"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "nervous_system"
+        "oncological"
       ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
+      "medication": [
+        "administration_method"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "education"
+        "gender"
       ]
     }
   },
@@ -727,42 +794,35 @@
     ],
     "pi_lead": "David van Heel",
     "website": "http://www.genesandhealth.org/",
+    "current_enrollment": 41500,
+    "target_enrollment": 100000,
+    "enrollment_period": "2015 - ongoing (planned end date 2023)",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "availability"
-        ],
         "data_type": [
-          "eQTL"
+          "WGS"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
+      "lifestyle_and_behaviours": [
+        "physical_activity"
       ],
       "general_variables": [
-        "physician_practitioner_info"
+        "signs_and_symptoms"
       ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      }
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
     },
     "survey_administration": [
-      "unique_identifiers"
+      "consent_accessibility"
     ]
   },
   {
@@ -772,11 +832,19 @@
     ],
     "pi_lead": "Paulo A. Lotufo",
     "website": "www.elsa.org.br",
+    "current_enrollment": 15105,
+    "target_enrollment": null,
+    "enrollment_period": "2008:2010",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
     },
     "biosample": {
       "sample_type": [
@@ -786,37 +854,25 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
+          "associated_phenotype"
         ],
         "data_type": [
-          "WES"
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
       "medication": [
-        "administration_method"
+        "drug_responses"
       ],
       "non_pharmacological_interventions": [
         "surgical_interventions"
       ],
       "physiological_measurements": {
-        "anthropometry": [
-          "height"
+        "cirulation_and_respiration": [
+          "blood_pressure"
         ]
-      },
-      "general_variables": [
-        "signs_and_symptoms"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
+      }
     }
   },
   {
@@ -826,22 +882,25 @@
     ],
     "pi_lead": "Matt Gillman",
     "website": "https://www.nih.gov/echo",
+    "current_enrollment": null,
+    "target_enrollment": 100000,
+    "enrollment_period": "1980:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "biosample": {
-      "sample_type": [
-        "saliva"
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "population_data": [
+        "location"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "processing_method"
-        ],
         "data_type": [
           "WES"
         ]
@@ -849,15 +908,17 @@
     },
     "questionnaire_survey_data": {
       "general_variables": [
-        "life_stage_time_point"
+        "physician_practitioner_info"
       ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
   },
   {
     "cohort_name": "EPIC (European Prospective Investigation into Cancer, Chronic Diseases, Nutrition and Lifestyle)",
@@ -875,41 +936,40 @@
     ],
     "pi_lead": "Elio Riboli, Paul Brennan, and Marc Gunter",
     "website": "http://epic.iarc.fr/",
+    "current_enrollment": 521000,
+    "target_enrollment": null,
+    "enrollment_period": "1992:1999",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "timeline"
-      ],
-      "population_data": [
-        "location"
+    "biosample": {
+      "sample_type": [
+        "blood"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
         "data_type": [
-          "Sequence_variants"
+          "other"
+        ],
+        "general_variables": [
+          "sample_size"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "medication": [
-        "administration_method"
-      ],
-      "general_variables": [
-        "signs_and_symptoms"
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
       ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
+    }
   },
   {
     "cohort_name": "EpiHealth",
@@ -918,6 +978,9 @@
     ],
     "pi_lead": "Lars Lind and S\u221a\u2202lve Elmst\u221a\u2022lh",
     "website": "https://www.epihealth.se/vad-ar-epihealth/",
+    "current_enrollment": 25000,
+    "target_enrollment": 25000,
+    "enrollment_period": "2011:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
@@ -925,30 +988,40 @@
       "phenotypic_clinical_data": true
     },
     "basic_cohort_attributes": {
-      "general_variables": [
-        "timeline"
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "data_type": [
-          "WGS"
+          "other"
         ],
         "general_variables": [
           "processing_method"
         ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
+      }
     },
     "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
       "medication": [
-        "prescription"
+        "associated_diseases"
       ],
-      "general_variables": [
-        "signs_and_symptoms"
-      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
       "socio_demographic_and_economic_characteristics": [
         "gender"
       ]
@@ -961,6 +1034,9 @@
     ],
     "pi_lead": "Andres Metspalu",
     "website": "www.biobank.ee",
+    "current_enrollment": 200000,
+    "target_enrollment": 200000,
+    "enrollment_period": "2002:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -972,30 +1048,33 @@
         "data_collection_events"
       ],
       "demographic_data": [
-        "genders_studied_in_cohort"
+        "sexes_studied_in_cohort"
       ]
     },
     "biosample": {
       "sample_type": [
-        "saliva"
+        "stool"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "sample_size"
-        ],
         "data_type": [
-          "WGS"
+          "WES"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "medication": [
-        "drug_responses"
+      "diseases": [
+        "nervous_system"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
+      "medication": [
+        "administration_method"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
       ]
     }
   },
@@ -1006,30 +1085,43 @@
     ],
     "pi_lead": "Helj\u221a\u00a7-Marja Surcel",
     "website": "www.esis.fi",
+    "current_enrollment": 950000,
+    "target_enrollment": null,
+    "enrollment_period": "1983:2016",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": false
     },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
       ]
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "nervous_system"
+      "lifestyle_and_behaviours": [
+        "tobacco"
       ],
       "medication": [
-        "associated_diseases"
+        "drug_responses"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
       ]
     },
-    "survey_administration": [
-      "unique_identifiers"
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
     ]
   },
   {
@@ -1044,38 +1136,42 @@
     ],
     "pi_lead": "Anthony Swerdlow",
     "website": "http://www.breakthroughgenerations.org.uk/home",
+    "current_enrollment": 113000,
+    "target_enrollment": 100000,
+    "enrollment_period": "2003:2015",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
     "biosample": {
       "sample_type": [
-        "blood"
+        "saliva"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "associated_phenotype"
+        "data_type": [
+          "WES"
         ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
+      }
     },
     "questionnaire_survey_data": {
       "diseases": [
         "endocrine_nutritional_metabolic_disorders"
       ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      }
+    }
   },
   {
     "cohort_name": "Healthy Nevada",
@@ -1084,6 +1180,9 @@
     ],
     "pi_lead": "Joe Grzymski",
     "website": "Healthynv.org",
+    "current_enrollment": 35000,
+    "target_enrollment": 250000,
+    "enrollment_period": "2016:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -1098,24 +1197,27 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
+          "associated_disease"
         ],
         "data_type": [
-          "RNAseq_gene_expression"
+          "other"
         ]
-      },
-      "microbiology": [
-        "biosample_source_anatomical_location"
-      ]
+      }
     },
     "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "sleep"
+      "diseases": [
+        "digestive_system"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
       ]
-    }
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
   },
   {
     "cohort_name": "Israel Genome Project",
@@ -1124,9 +1226,142 @@
     ],
     "pi_lead": "Gad Rennert",
     "website": "",
+    "current_enrollment": 140000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "RNAseq_gene_expression"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study (JPHC)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "http://epi.ncc.go.jp/en/jphc/",
+    "current_enrollment": 130000,
+    "target_enrollment": null,
+    "enrollment_period": "1990:1994",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "https://epi.ncc.go.jp/jphcnext/en/index.html",
+    "current_enrollment": 115000,
+    "target_enrollment": null,
+    "enrollment_period": "2011:2016",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_disease"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Kaiser Permanente Research Program on Genes, Environment, and Health",
+    "countries": [
+      "USA; Northern California"
+    ],
+    "pi_lead": "Catherine Schaefer",
+    "website": "http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx",
+    "current_enrollment": 210000,
+    "target_enrollment": 500000,
+    "enrollment_period": "2008: ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
@@ -1137,9 +1372,6 @@
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ],
         "data_type": [
           "eQTL"
         ]
@@ -1147,7 +1379,111 @@
     },
     "questionnaire_survey_data": {
       "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Korea Biobank Project",
+    "countries": [
+      "Republic of Korea"
+    ],
+    "pi_lead": "Jae-Pil Jeon and Changhoon Kim",
+    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346",
+    "current_enrollment": 830000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
         "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Korean Cancer Prevention Study (KCPS-II Biobank)",
+    "countries": [
+      "Korea"
+    ],
+    "pi_lead": "Sun Ha Jee",
+    "website": "",
+    "current_enrollment": 156701,
+    "target_enrollment": null,
+    "enrollment_period": "2004:2013",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
       ],
       "general_variables": [
         "life_stage_time_point"
@@ -1159,22 +1495,288 @@
         "anthropometry": [
           "height"
         ]
-      },
+      }
+    }
+  },
+  {
+    "cohort_name": "LifeGene (and sister cohort, EpiHealth)",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Nancy Pedersen",
+    "website": "https://www.lifegene.se/For-scientists/About-LifeGene/",
+    "current_enrollment": 51300,
+    "target_enrollment": 300000,
+    "enrollment_period": "2009:2016",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "posology"
+      ]
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging)",
+    "countries": [
+      "Europe (7)",
+      "Australia",
+      "USA"
+    ],
+    "pi_lead": "Terrence Simmons",
+    "website": "http://www.lifepathproject.eu/",
+    "current_enrollment": 235000,
+    "target_enrollment": null,
+    "enrollment_period": "Varies by cohort",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "prescription"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "age_birthdate"
+        "gender"
       ]
     }
   },
   {
-    "cohort_name": "Japan Public Health Center-based Prospective Study (JPHC)",
+    "cohort_name": "Malaysian Cohort",
     "countries": [
-      "Japan"
+      "Malaysia"
     ],
-    "pi_lead": "Shoichiro Tsugane",
-    "website": "http://epi.ncc.go.jp/en/jphc/",
+    "pi_lead": "Rahman Jamal",
+    "website": "http://mycohort.gov.my/site/",
+    "current_enrollment": 106527,
+    "target_enrollment": null,
+    "enrollment_period": "2007:2013",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Maule Cohort (MAUCO Study)",
+    "countries": [
+      "Chile"
+    ],
+    "pi_lead": "Catterina Ferreccio",
+    "website": "http://www.accdis.cl/eng/en/",
+    "current_enrollment": 9200,
+    "target_enrollment": 10000,
+    "enrollment_period": "2015:2018",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Mexico City Prospective Study",
+    "countries": [
+      "Mexico"
+    ],
+    "pi_lead": "Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, and Roberto Tapia-Conyer",
+    "website": "https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico",
+    "current_enrollment": 159755,
+    "target_enrollment": null,
+    "enrollment_period": "1998:2004",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ],
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Veteran Program",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Mike Gaziano",
+    "website": "http://www.research.va.gov/mvp/",
+    "current_enrollment": 785000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "2011:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "DNA_Genotyping"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Women Study",
+    "countries": [
+      "England",
+      "Scotland"
+    ],
+    "pi_lead": "Valerie Beral",
+    "website": "http://www.millionwomenstudy.org/introduction/",
+    "current_enrollment": 1320000,
+    "target_enrollment": null,
+    "enrollment_period": "1996:2001",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
@@ -1191,507 +1793,25 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
-        ],
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "medication": [
-        "associated_diseases"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT)",
-    "countries": [
-      "Japan"
-    ],
-    "pi_lead": "Shoichiro Tsugane",
-    "website": "https://epi.ncc.go.jp/jphcnext/en/index.html",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "location"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_disease"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "education"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Kaiser Permanente Research Program on Genes, Environment, and Health",
-    "countries": [
-      "USA; Northern California"
-    ],
-    "pi_lead": "Catherine Schaefer",
-    "website": "http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "genders_studied_in_cohort"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
-        ],
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "education"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "Korea Biobank Project",
-    "countries": [
-      "Republic of Korea"
-    ],
-    "pi_lead": "Jae-Pil Jeon and Changhoon Kim",
-    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "data_collection_events"
-      ],
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
-        ],
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "medication": [
-        "drug_responses"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      }
-    }
-  },
-  {
-    "cohort_name": "Korean Cancer Prevention Study (KCPS-II Biobank)",
-    "countries": [
-      "Korea"
-    ],
-    "pi_lead": "Sun Ha Jee",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Epigenetics"
-        ],
-        "general_variables": [
           "sample_size"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological"
+        "nervous_system"
       ],
       "general_variables": [
         "life_stage_time_point"
       ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ]
-    }
-  },
-  {
-    "cohort_name": "LifeGene (and sister cohort, EpiHealth)",
-    "countries": [
-      "Sweden"
-    ],
-    "pi_lead": "Nancy Pedersen",
-    "website": "https://www.lifegene.se/For-scientists/About-LifeGene/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ],
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "medication": [
-        "posology"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
-      ]
-    }
-  },
-  {
-    "cohort_name": "LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging)",
-    "countries": [
-      "Europe (7)",
-      "Australia",
-      "USA"
-    ],
-    "pi_lead": "Terrence Simmons",
-    "website": "http://www.lifepathproject.eu/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "blood"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "medication": [
-        "posology"
-      ]
-    },
-    "survey_administration": [
-      "date_and_time_related_information"
-    ]
-  },
-  {
-    "cohort_name": "Malaysian Cohort",
-    "countries": [
-      "Malaysia"
-    ],
-    "pi_lead": "Rahman Jamal",
-    "website": "http://mycohort.gov.my/site/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ],
-        "general_variables": [
-          "sample_size"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "medication": [
-        "administration_method"
-      ],
       "physiological_measurements": {
         "cirulation_and_respiration": [
-          "blood_pressure"
+          "heart_rate"
         ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "gender"
-      ]
+      }
     },
     "survey_administration": [
       "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Maule Cohort (MAUCO Study)",
-    "countries": [
-      "Chile"
-    ],
-    "pi_lead": "Catterina Ferreccio",
-    "website": "http://www.accdis.cl/eng/en/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Mexico City Prospective Study",
-    "countries": [
-      "Mexico"
-    ],
-    "pi_lead": "Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, and Roberto Tapia-Conyer",
-    "website": "https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ],
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "processing_method"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "gender"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Million Veteran Program",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Mike Gaziano",
-    "website": "http://www.research.va.gov/mvp/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "study_design"
-      ],
-      "demographic_data": [
-        "genders_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "eQTL"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "digestive_system"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
-      "general_variables": [
-        "signs_and_symptoms"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Million Women Study",
-    "countries": [
-      "England",
-      "Scotland"
-    ],
-    "pi_lead": "Valerie Beral",
-    "website": "http://www.millionwomenstudy.org/introduction/",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "saliva"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "medication": [
-        "drug_responses"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      }
-    },
-    "survey_administration": [
-      "consent_accessibility"
     ]
   },
   {
@@ -1701,6 +1821,9 @@
     ],
     "pi_lead": "Loic Le Marchand",
     "website": "https://www.uhcancercenter.org/mec",
+    "current_enrollment": 215251,
+    "target_enrollment": null,
+    "enrollment_period": "1993:1997",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -1713,31 +1836,22 @@
       ]
     },
     "biosample": {
-      "general_variables": [
-        "storage_method"
+      "sample_type": [
+        "urine"
       ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Sequence_variants"
-        ]
-      }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "blood_related_disorders"
+        "oncological"
       ],
-      "general_variables": [
-        "physician_practitioner_info"
+      "lifestyle_and_behaviours": [
+        "sleep"
       ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
+      "medication": [
+        "posology"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
+        "genealogy"
       ]
     },
     "survey_administration": [
@@ -1751,155 +1865,9 @@
     ],
     "pi_lead": "David H Ledbetter",
     "website": "https://www.geisinger.org/mycode",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "nutrition"
-      ],
-      "medication": [
-        "associated_diseases"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
-    },
-    "survey_administration": [
-      "consent_accessibility"
-    ]
-  },
-  {
-    "cohort_name": "Netherlands Twin Registry",
-    "countries": [
-      "Netherlands"
-    ],
-    "pi_lead": "Dorret Boomsma",
-    "website": "http://www.tweelingenregister.org/en/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ],
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      }
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Newfoundland 100K Genome Project / Sequence Bio",
-    "countries": [
-      "Canada (Province of Newfoundland and Labrador)"
-    ],
-    "pi_lead": "Michael Phillips",
-    "website": "https://www.sequencebio.com/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
-        ],
-        "data_type": [
-          "WES"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "medication": [
-        "prescription"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "NHS (Nurses' Health Study, NCI)",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Meir Stampfer, Rulla Tamimi",
-    "website": "www.nurseshealthstudy.org",
+    "current_enrollment": 252160,
+    "target_enrollment": 250000,
+    "enrollment_period": "2007:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -1908,8 +1876,184 @@
     },
     "basic_cohort_attributes": {
       "general_variables": [
-        "data_collection_events"
+        "timeline"
       ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Netherlands Twin Registry",
+    "countries": [
+      "Netherlands"
+    ],
+    "pi_lead": "Dorret Boomsma",
+    "website": "http://www.tweelingenregister.org/en/",
+    "current_enrollment": 275000,
+    "target_enrollment": null,
+    "enrollment_period": "1987:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Newfoundland 100K Genome Project / Sequence Bio",
+    "countries": [
+      "Canada (Province of Newfoundland and Labrador)"
+    ],
+    "pi_lead": "Michael Phillips",
+    "website": "https://www.sequencebio.com/",
+    "current_enrollment": 520000,
+    "target_enrollment": null,
+    "enrollment_period": "2018:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "NHS (Nurses' Health Study, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Meir Stampfer, Rulla Tamimi",
+    "website": "www.nurseshealthstudy.org",
+    "current_enrollment": 121700,
+    "target_enrollment": null,
+    "enrollment_period": "1976:1976",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "NHSII (Nurses' Health Study II, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Walter Willett, Heather Eliassen",
+    "website": "www.nurseshealthstudy.org",
+    "current_enrollment": 116430,
+    "target_enrollment": null,
+    "enrollment_period": "1989:1989",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
     },
     "laboratory_measures": {
       "genomics": {
@@ -1919,15 +2063,9 @@
         "data_type": [
           "WGS"
         ]
-      },
-      "microbiology": [
-        "biosample_source_anatomical_location"
-      ]
+      }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
       "medication": [
         "prescription"
       ],
@@ -1935,57 +2073,9 @@
         "cirulation_and_respiration": [
           "blood_pressure"
         ]
-      }
-    },
-    "survey_administration": [
-      "consent_accessibility"
-    ]
-  },
-  {
-    "cohort_name": "NHSII (Nurses' Health Study II, NCI)",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Walter Willett, Heather Eliassen",
-    "website": "www.nurseshealthstudy.org",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "aims_and_objectives"
-      ]
-    },
-    "biosample": {
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
-        "data_type": [
-          "WES"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "nutrition"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "general_variables": [
-        "signs_and_symptoms"
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
       ]
     }
   },
@@ -1996,152 +2086,31 @@
     ],
     "pi_lead": "Rennert Gad",
     "website": "",
+    "current_enrollment": 40000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "data_collection_events"
+    "biosample": {
+      "sample_type": [
+        "urine"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "sample_size"
+          "available_data_formats"
         ],
         "data_type": [
-          "RNAseq_gene_expression"
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "circulatory_system"
-      ],
-      "medication": [
-        "posology"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "Northern Sweden Health and Disease Study",
-    "countries": [
-      "Sweden"
-    ],
-    "pi_lead": "Beatrice Melin",
-    "website": "http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "medication": [
-        "posology"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "birthplace"
-      ]
-    },
-    "survey_administration": [
-      "date_and_time_related_information"
-    ]
-  },
-  {
-    "cohort_name": "Norwegian Family Based Life Course Study",
-    "countries": [
-      "Norway"
-    ],
-    "pi_lead": "\u221a\u00f2yvind N\u221a\u00b6ss",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ],
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "medication": [
-        "posology"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Norwegian Mother and Child Cohort Study (MoBa)",
-    "countries": [
-      "Norway"
-    ],
-    "pi_lead": "Per Magnus",
-    "website": "https://www.fhi.no/en/studies/moba/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Sequence_variants"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "nervous_system"
-      ],
       "general_variables": [
         "life_stage_time_point"
       ],
@@ -2154,7 +2123,155 @@
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "age_birthdate"
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Northern Sweden Health and Disease Study",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Beatrice Melin",
+    "website": "http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/",
+    "current_enrollment": 135000,
+    "target_enrollment": null,
+    "enrollment_period": "1985 : ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Norwegian Family Based Life Course Study",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "\u221a\u00f2yvind N\u221a\u00b6ss",
+    "website": "",
+    "current_enrollment": 5266270,
+    "target_enrollment": null,
+    "enrollment_period": "1960:2011",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Norwegian Mother and Child Cohort Study (MoBa)",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "Per Magnus",
+    "website": "https://www.fhi.no/en/studies/moba/",
+    "current_enrollment": 284000,
+    "target_enrollment": null,
+    "enrollment_period": "1999:2008",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ],
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WES"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "circulatory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
       ]
     }
   },
@@ -2165,39 +2282,46 @@
     ],
     "pi_lead": "Danish Salaheen",
     "website": "https://www.cncdpk.com/page/Pakistan-Genomic-Resource-(PGR)",
+    "current_enrollment": 150000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
       "biospecimens": false,
       "phenotypic_clinical_data": false
     },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ],
-      "general_variables": [
-        "timeline"
-      ]
-    },
     "biosample": {
-      "sample_type": [
-        "saliva"
+      "general_variables": [
+        "storage_method"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "education"
+        "residence"
       ]
     },
-    "survey_administration": [
-      "date_and_time_related_information"
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
     ]
   },
   {
@@ -2207,11 +2331,22 @@
     ],
     "pi_lead": "Reza Malekzadeh,  Hossein Poustchi,  Farin Kamangar,  Arash Etemadi",
     "website": "http://persiancohort.com",
+    "current_enrollment": 180000,
+    "target_enrollment": null,
+    "enrollment_period": "2014:ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "population_data": [
+        "location"
+      ]
     },
     "biosample": {
       "sample_type": [
@@ -2220,20 +2355,23 @@
     },
     "laboratory_measures": {
       "genomics": {
+        "data_type": [
+          "RNAseq_gene_expression"
+        ],
         "general_variables": [
           "processing_method"
-        ],
-        "data_type": [
-          "WES"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "respiratory_system"
+        "blood_related_disorders"
       ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
       ]
     }
   },
@@ -2244,6 +2382,9 @@
     ],
     "pi_lead": "Paul Pinsky and Neal Freedman",
     "website": "http://prevention.cancer.gov/major-programs/prostate-lung-colorectal",
+    "current_enrollment": 154907,
+    "target_enrollment": null,
+    "enrollment_period": "1993:2001",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -2253,7 +2394,7 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_disease"
+          "availability"
         ],
         "data_type": [
           "eQTL"
@@ -2261,11 +2402,19 @@
       }
     },
     "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "tobacco"
+      "diseases": [
+        "mental_and_behaviour_disorders"
       ],
-      "medication": [
-        "prescription"
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
       ]
     }
   },
@@ -2276,6 +2425,9 @@
     ],
     "pi_lead": "Hamdi Mbarek",
     "website": "https://qatargenome.org.qa/",
+    "current_enrollment": 15000,
+    "target_enrollment": 300000,
+    "enrollment_period": "2015: ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -2283,29 +2435,27 @@
       "phenotypic_clinical_data": true
     },
     "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
       ]
     },
     "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "sample_size"
-        ],
-        "data_type": [
-          "eQTL"
-        ]
-      },
       "microbiology": [
-        "microbial_data"
+        "biosample_source_anatomical_location"
       ]
     },
     "questionnaire_survey_data": {
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
+      "diseases": [
+        "oncological"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
       ]
     }
   },
@@ -2316,6 +2466,9 @@
     ],
     "pi_lead": "Sultan AlSudiri and Malak Abedalthagafi",
     "website": "http://shgp.kacst.edu.sa/site/",
+    "current_enrollment": 100000,
+    "target_enrollment": null,
+    "enrollment_period": "",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -2323,34 +2476,34 @@
       "phenotypic_clinical_data": false
     },
     "basic_cohort_attributes": {
-      "demographic_data": [
-        "genders_studied_in_cohort"
+      "population_data": [
+        "num_participants"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
         "data_type": [
-          "WES"
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "respiratory_system"
+        "circulatory_system"
       ],
       "lifestyle_and_behaviours": [
-        "sleep"
+        "alcohol"
       ],
-      "medication": [
-        "prescription"
+      "general_variables": [
+        "signs_and_symptoms"
       ],
       "socio_demographic_and_economic_characteristics": [
-        "birthplace"
+        "ethnicity_race"
       ]
-    }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
   },
   {
     "cohort_name": "Saudi National Biobank",
@@ -2359,45 +2512,9 @@
     ],
     "pi_lead": "Ada Al-Qunaibet",
     "website": "http://www.ksau-hs.edu.sa/English/Research/Pages/KAIMRC.aspx",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "location"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ],
-        "cirulation_and_respiration": [
-          "blood_pressure"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Shanghai Men and Women's Health Study (2 cohorts)",
-    "countries": [
-      "Shanghai",
-      "China"
-    ],
-    "pi_lead": "Wei Zheng",
-    "website": "http://www.mc.vanderbilt.edu/swhs-smhs/",
+    "current_enrollment": 2000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -2406,351 +2523,8 @@
     },
     "basic_cohort_attributes": {
       "general_variables": [
-        "data_collection_events"
+        "aims_and_objectives"
       ]
-    },
-    "biosample": {
-      "sample_type": [
-        "blood"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "sample_size"
-        ],
-        "data_type": [
-          "eQTL"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "medication": [
-        "posology"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Singapore National Precision Medicine Program",
-    "countries": [
-      "Singapore"
-    ],
-    "pi_lead": "Patrick Tan and E Shyong Tai",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "South(east) Asian Cohorts - NETWORK",
-    "countries": [
-      "Bangladesh",
-      "Malaysia",
-      "Sri Lanka"
-    ],
-    "pi_lead": "Rajiv Chowdhury",
-    "website": "http://www.phpc.cam.ac.uk/ceu/international-vascular-health/believe/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Taiwan Biobank",
-    "countries": [
-      "Taiwan"
-    ],
-    "pi_lead": "Te-Chang Lee and Chung-ke Chang",
-    "website": "https://www.twbiobank.org.tw/new_web/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "location"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "saliva"
-      ]
-    },
-    "laboratory_measures": {
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
-    },
-    "survey_administration": [
-      "consent_accessibility"
-    ]
-  },
-  {
-    "cohort_name": "U.S. Precision Medicine Initiative / All of Us",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Stephanie Devaney",
-    "website": "https://allofus.nih.gov/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ],
-      "general_variables": [
-        "timeline"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
-        ],
-        "data_type": [
-          "DNA_Genotyping"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "alcohol"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "UK Biobank",
-    "countries": [
-      "England",
-      "Scotland",
-      "Wales"
-    ],
-    "pi_lead": "Rory Collins",
-    "website": "http://www.ukbiobank.ac.uk/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ],
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "education"
-      ]
-    }
-  },
-  {
-    "cohort_name": "UK Blood Donor Cohorts",
-    "countries": [
-      "UK"
-    ],
-    "pi_lead": "Emanuele Di Angelantonio and John Danesh",
-    "website": "http://www.intervalstudy.org.uk/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "study_design"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_medication"
-        ],
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "medication": [
-        "associated_diseases"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
-      ]
-    }
-  },
-  {
-    "cohort_name": "UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women's Cohort UKLWC",
-    "countries": [
-      "England",
-      "Wales",
-      "Northern Ireland"
-    ],
-    "pi_lead": "Usha Menon",
-    "website": "http://www.isrctn.com/ISRCTN22488978",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Vorarlberg Health Monitoring and Promotion Programme (VHM&PP)",
-    "countries": [
-      "Austria"
-    ],
-    "pi_lead": "Hans Concin, Gabriele Nagel, Hanno Ulmer",
-    "website": "http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
     },
     "biosample": {
       "sample_type": [
@@ -2765,25 +2539,429 @@
       }
     },
     "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Shanghai Men and Women's Health Study (2 cohorts)",
+    "countries": [
+      "Shanghai",
+      "China"
+    ],
+    "pi_lead": "Wei Zheng",
+    "website": "http://www.mc.vanderbilt.edu/swhs-smhs/",
+    "current_enrollment": 136000,
+    "target_enrollment": null,
+    "enrollment_period": "1996:2000",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Singapore National Precision Medicine Program",
+    "countries": [
+      "Singapore"
+    ],
+    "pi_lead": "Patrick Tan and E Shyong Tai",
+    "website": "",
+    "current_enrollment": 10000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "10 year program",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
       "diseases": [
-        "nervous_system"
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "South(east) Asian Cohorts - NETWORK",
+    "countries": [
+      "Bangladesh",
+      "Malaysia",
+      "Sri Lanka"
+    ],
+    "pi_lead": "Rajiv Chowdhury",
+    "website": "http://www.phpc.cam.ac.uk/ceu/international-vascular-health/believe/",
+    "current_enrollment": 75000,
+    "target_enrollment": 150000,
+    "enrollment_period": "2010:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Taiwan Biobank",
+    "countries": [
+      "Taiwan"
+    ],
+    "pi_lead": "Te-Chang Lee and Chung-ke Chang",
+    "website": "https://www.twbiobank.org.tw/new_web/",
+    "current_enrollment": 118548,
+    "target_enrollment": 200000,
+    "enrollment_period": "2012:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "medication": [
+        "posology"
+      ]
+    }
+  },
+  {
+    "cohort_name": "U.S. Precision Medicine Initiative / All of Us",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Stephanie Devaney",
+    "website": "https://allofus.nih.gov/",
+    "current_enrollment": 191105,
+    "target_enrollment": 1000000,
+    "enrollment_period": "2018:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
       ],
       "lifestyle_and_behaviours": [
         "sleep"
       ],
       "medication": [
-        "prescription"
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UK Biobank",
+    "countries": [
+      "England",
+      "Scotland",
+      "Wales"
+    ],
+    "pi_lead": "Rory Collins",
+    "website": "http://www.ukbiobank.ac.uk/",
+    "current_enrollment": 502713,
+    "target_enrollment": 500000,
+    "enrollment_period": "2006:2010",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UK Blood Donor Cohorts",
+    "countries": [
+      "UK"
+    ],
+    "pi_lead": "Emanuele Di Angelantonio and John Danesh",
+    "website": "http://www.intervalstudy.org.uk/",
+    "current_enrollment": 100000,
+    "target_enrollment": 350000,
+    "enrollment_period": "2012:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women\u201a\u00c4\u00f4s Cohort UKLWC",
+    "countries": [
+      "England",
+      "Wales",
+      "Northern Ireland"
+    ],
+    "pi_lead": "Usha Menon",
+    "website": "http://www.isrctn.com/ISRCTN22488978",
+    "current_enrollment": 202638,
+    "target_enrollment": null,
+    "enrollment_period": "2001:2005",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Vorarlberg Health Monitoring and Promotion Programme (VHM&PP)",
+    "countries": [
+      "Austria"
+    ],
+    "pi_lead": "Hans Concin, Gabriele Nagel, Hanno Ulmer",
+    "website": "http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs",
+    "current_enrollment": 180000,
+    "target_enrollment": null,
+    "enrollment_period": "1985:2014",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
       ],
       "general_variables": [
         "physician_practitioner_info"
       ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
       "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
+        "education"
       ]
     }
   },
@@ -2794,44 +2972,49 @@
     ],
     "pi_lead": "Garnet Anderson",
     "website": "https://deino.whiops.org/go/www.whi.org~ssl/SitePages/WHI%20Home.aspx",
+    "current_enrollment": 161808,
+    "target_enrollment": null,
+    "enrollment_period": "1993:1998",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
     "laboratory_measures": {
       "genomics": {
         "data_type": [
-          "other"
-        ],
-        "general_variables": [
-          "sample_size"
+          "RNAseq_gene_expression"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological"
+        "nervous_system"
       ],
-      "lifestyle_and_behaviours": [
-        "nutrition"
+      "medication": [
+        "prescription"
       ],
       "non_pharmacological_interventions": [
         "surgical_interventions"
       ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
+        "birthplace"
       ]
     },
     "survey_administration": [
-      "date_and_time_related_information"
+      "consent_accessibility"
     ]
   }
 ]
-

--- a/data/metadata.json
+++ b/data/metadata.json
@@ -1,26 +1,31 @@
 {
 	"Golestan Cohort Study": {
 		"id": "GCS",
+		"prefix": "GCS",
 		"data_dictionary": "https://drive.google.com/file/d/1ZLw-D6AZFKrBjTNsc4wzlthYq4w4KmOJ/view",
 		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=1184636935"
 	},
 	"Korean Genome and Epidemiology Study (KoGES)": {
 		"id": "KoGES",
+		"prefix": "KoGES",
 		"data_dictionary": "https://drive.google.com/file/d/1Hh_cG9HcZWXs70FEun8iDZZbt0H_J1oq/view",
 		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=737702084"
 	},
 	"Genomics England / 100,000 Genomes Project": {
-		"id": "Genomics England",
+		"id": "Genomics-England",
+		"prefix": "GE",
 		"data_dictionary": "https://cnfl.extge.co.uk/pages/viewpage.action?pageId=113189195",
 		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=888808694"
 	},
 	"SAPRIN (South African Population Research Infrastructure Network)": {
 		"id": "SAPRIN",
+		"prefix": "SAPRIN",
 		"data_dictionary": "https://drive.google.com/file/d/1u1sXEAAU7N_n2-WqfF6lMJozVVQSI0EU",
 		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=2135840437"
 	},
 	"Africa Health Research Institute (AHRI) Population Cohort": {
 		"id": "Vukuzazi",
+		"prefix": "VZ",
 		"data_dictionary": "https://drive.google.com/file/d/1YpwjiYDos5ZkXMQR6wG4Qug7sMmKB5xC/view",
 		"mapping": "https://docs.google.com/spreadsheets/d/1IRAv5gKADr329kx2rJnJgtpYYqUhZcwLutKke8Q48j4/edit#gid=817993717"
 	}

--- a/data/random-data.json
+++ b/data/random-data.json
@@ -6,45 +6,33 @@
     ],
     "pi_lead": "Joyce Tung",
     "website": "https://research.23andme.com/",
+    "current_enrollment": 6800000,
+    "target_enrollment": null,
+    "enrollment_period": "2007:Ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "timeline"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
     "laboratory_measures": {
       "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
         "data_type": [
-          "Sequence_variants"
+          "WGS"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "digestive_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "blood_pressure"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
+      "medication": [
+        "drug_responses"
       ]
-    }
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
   },
   {
     "cohort_name": "45 and Up Study",
@@ -53,18 +41,18 @@
     ],
     "pi_lead": "Martin McNamara",
     "website": "https://www.saxinstitute.org.au/our-work/45-up-study/",
+    "current_enrollment": 267153,
+    "target_enrollment": null,
+    "enrollment_period": "2006:2009",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "biosample": {
-      "sample_type": [
-        "saliva"
-      ],
+    "basic_cohort_attributes": {
       "general_variables": [
-        "storage_method"
+        "aims_and_objectives"
       ]
     },
     "laboratory_measures": {
@@ -76,15 +64,24 @@
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "nervous_system"
+        "digestive_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
       ],
       "lifestyle_and_behaviours": [
         "sleep"
       ],
+      "medication": [
+        "prescription"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "genealogy"
+        "education"
       ]
-    }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
   },
   {
     "cohort_name": "Apolipoprotein MORtality RISk study (AMORIS)",
@@ -93,89 +90,12 @@
     ],
     "pi_lead": "Goran Walldius",
     "website": "http://amoriscohort.imm.ki.se",
+    "current_enrollment": 812073,
+    "target_enrollment": null,
+    "enrollment_period": "1985:1996",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "microbiology": [
-        "biosample_source_anatomical_location"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Biobank Japan",
-    "countries": [
-      "Japan"
-    ],
-    "pi_lead": "Yoshinori Murakami",
-    "website": "https://biobankjp.org/english/index.html",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_medication"
-        ],
-        "data_type": [
-          "Metagenomics"
-        ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "BioVU Vanderbilt",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Dan Roden",
-    "website": "https://victr.vanderbilt.edu/pub/biovu/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
@@ -187,58 +107,10 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
+          "associated_phenotype"
         ],
         "data_type": [
           "Metagenomics"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "medication": [
-        "prescription"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Canadian Partnership for Tomorrow Project (CPTP)",
-    "countries": [
-      "Canada"
-    ],
-    "pi_lead": "Philip Awadalla",
-    "website": "http://www.partnershipfortomorrow.ca",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "genders_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
         ]
       },
       "microbiology": [
@@ -246,70 +118,27 @@
       ]
     },
     "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
       "lifestyle_and_behaviours": [
-        "nutrition"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
+        "sleep"
       ]
     },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
+    "survey_administration": [
+      "unique_identifiers"
     ]
   },
   {
-    "cohort_name": "Cancer Prevention Study II (CPS-II)",
+    "cohort_name": "Biobank Japan",
     "countries": [
-      "USA"
+      "Japan"
     ],
-    "pi_lead": "Susan Gapstur",
-    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": false,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "data_collection_events"
-      ],
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ],
-        "data_type": [
-          "RNAseq_gene_expression"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "nervous_system"
-      ],
-      "medication": [
-        "prescription"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "gender"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Cancer Prevention Study II Nutrition Cohort",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Susan Gapstur",
-    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study",
+    "pi_lead": "Yoshinori Murakami",
+    "website": "https://biobankjp.org/english/index.html",
+    "current_enrollment": 270000,
+    "target_enrollment": 270000,
+    "enrollment_period": "2003:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -320,21 +149,69 @@
       "genomics": {
         "general_variables": [
           "sample_size"
-        ],
-        "data_type": [
-          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "BioVU Vanderbilt",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Dan Roden",
+    "website": "https://victr.vanderbilt.edu/pub/biovu/",
+    "current_enrollment": 244000,
+    "target_enrollment": null,
+    "enrollment_period": "2007:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ],
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
         ]
       }
     },
     "questionnaire_survey_data": {
       "lifestyle_and_behaviours": [
-        "sleep"
+        "nutrition"
       ],
       "medication": [
-        "drug_responses"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
+        "prescription"
       ],
       "physiological_measurements": {
         "anthropometry": [
@@ -342,11 +219,150 @@
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Canadian Partnership for Tomorrow Project (CPTP)",
+    "countries": [
+      "Canada"
+    ],
+    "pi_lead": "Philip Awadalla",
+    "website": "http://www.partnershipfortomorrow.ca",
+    "current_enrollment": 315000,
+    "target_enrollment": null,
+    "enrollment_period": "2008:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ],
+      "demographic_data": [
+        "age_range"
       ]
     },
-    "survey_administration": [
-      "unique_identifiers"
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "circulatory_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II (CPS-II)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index",
+    "current_enrollment": 1185106,
+    "target_enrollment": null,
+    "enrollment_period": "1982:1983",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": false,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "Epigenetics"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II Nutrition Cohort",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study",
+    "current_enrollment": 184194,
+    "target_enrollment": null,
+    "enrollment_period": "1992:1993",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
     ]
   },
   {
@@ -361,8 +377,108 @@
     ],
     "pi_lead": "Hakon Hakonarson",
     "website": "https://caglab.org/index.php/for-researchers/biorepository.html",
+    "current_enrollment": 500000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "2006:ongoing",
     "available_data_types": {
       "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "China Kadoorie Biobank",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Zhengming Chen and Liming Li",
+    "website": "http://www.ckbiobank.org/site/",
+    "current_enrollment": 512891,
+    "target_enrollment": null,
+    "enrollment_period": "2004:2008",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Linxin Jiang",
+    "website": "",
+    "current_enrollment": 2000000,
+    "target_enrollment": 4000000,
+    "enrollment_period": "2014:ongoing",
+    "available_data_types": {
+      "genomic_data": false,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
@@ -378,98 +494,16 @@
     "laboratory_measures": {
       "genomics": {
         "data_type": [
-          "eQTL"
+          "WGS"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological"
+        "digestive_system"
       ],
       "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      }
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "China Kadoorie Biobank",
-    "countries": [
-      "China"
-    ],
-    "pi_lead": "Zhengming Chen and Liming Li",
-    "website": "http://www.ckbiobank.org/site/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
-        ],
-        "data_type": [
-          "WES"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
-      ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "blood_pressure"
-        ]
-      }
-    }
-  },
-  {
-    "cohort_name": "China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project",
-    "countries": [
-      "China"
-    ],
-    "pi_lead": "Linxin Jiang",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ],
-        "data_type": [
-          "Sequence_variants"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
+        "sleep"
       ],
       "physiological_measurements": {
         "anthropometry": [
@@ -488,40 +522,49 @@
     ],
     "pi_lead": "Marie Zins",
     "website": "http://www.constances.fr/index_EN.php",
+    "current_enrollment": 210000,
+    "target_enrollment": null,
+    "enrollment_period": "2012:2019",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "biosample": {
-      "sample_type": [
-        "urine"
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "data_type": [
-          "WGS"
+        "general_variables": [
+          "sample_size"
         ]
       }
     },
     "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
       "lifestyle_and_behaviours": [
-        "alcohol"
+        "tobacco"
+      ],
+      "medication": [
+        "prescription"
       ],
       "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ],
         "cirulation_and_respiration": [
           "blood_pressure"
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "residence"
+        "birthplace"
       ]
-    },
-    "survey_administration": [
-      "date_and_time_related_information"
-    ]
+    }
   },
   {
     "cohort_name": "Danish National Birth Cohort",
@@ -530,6 +573,9 @@
     ],
     "pi_lead": "Mads Melbye",
     "website": "dnbc.dk",
+    "current_enrollment": 198028,
+    "target_enrollment": null,
+    "enrollment_period": "1998:2002",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -538,30 +584,36 @@
     },
     "basic_cohort_attributes": {
       "demographic_data": [
-        "age_range"
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "processing_method"
+          "available_data_formats"
         ],
         "data_type": [
-          "Sequence_variants"
+          "DNA_Genotyping"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "nervous_system"
+        "oncological"
       ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
+      "medication": [
+        "administration_method"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "education"
+        "gender"
       ]
     }
   },
@@ -572,42 +624,35 @@
     ],
     "pi_lead": "David van Heel",
     "website": "http://www.genesandhealth.org/",
+    "current_enrollment": 41500,
+    "target_enrollment": 100000,
+    "enrollment_period": "2015 - ongoing (planned end date 2023)",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "availability"
-        ],
         "data_type": [
-          "eQTL"
+          "WGS"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
+      "lifestyle_and_behaviours": [
+        "physical_activity"
       ],
       "general_variables": [
-        "physician_practitioner_info"
+        "signs_and_symptoms"
       ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      }
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
     },
     "survey_administration": [
-      "unique_identifiers"
+      "consent_accessibility"
     ]
   },
   {
@@ -617,11 +662,19 @@
     ],
     "pi_lead": "Paulo A. Lotufo",
     "website": "www.elsa.org.br",
+    "current_enrollment": 15105,
+    "target_enrollment": null,
+    "enrollment_period": "2008:2010",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
     },
     "biosample": {
       "sample_type": [
@@ -631,37 +684,25 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
+          "associated_phenotype"
         ],
         "data_type": [
-          "WES"
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
       "medication": [
-        "administration_method"
+        "drug_responses"
       ],
       "non_pharmacological_interventions": [
         "surgical_interventions"
       ],
       "physiological_measurements": {
-        "anthropometry": [
-          "height"
+        "cirulation_and_respiration": [
+          "blood_pressure"
         ]
-      },
-      "general_variables": [
-        "signs_and_symptoms"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
+      }
     }
   },
   {
@@ -671,22 +712,25 @@
     ],
     "pi_lead": "Matt Gillman",
     "website": "https://www.nih.gov/echo",
+    "current_enrollment": null,
+    "target_enrollment": 100000,
+    "enrollment_period": "1980:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "biosample": {
-      "sample_type": [
-        "saliva"
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "population_data": [
+        "location"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "processing_method"
-        ],
         "data_type": [
           "WES"
         ]
@@ -694,15 +738,17 @@
     },
     "questionnaire_survey_data": {
       "general_variables": [
-        "life_stage_time_point"
+        "physician_practitioner_info"
       ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
   },
   {
     "cohort_name": "EPIC (European Prospective Investigation into Cancer, Chronic Diseases, Nutrition and Lifestyle)",
@@ -720,41 +766,40 @@
     ],
     "pi_lead": "Elio Riboli, Paul Brennan, and Marc Gunter",
     "website": "http://epic.iarc.fr/",
+    "current_enrollment": 521000,
+    "target_enrollment": null,
+    "enrollment_period": "1992:1999",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "timeline"
-      ],
-      "population_data": [
-        "location"
+    "biosample": {
+      "sample_type": [
+        "blood"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
         "data_type": [
-          "Sequence_variants"
+          "other"
+        ],
+        "general_variables": [
+          "sample_size"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "medication": [
-        "administration_method"
-      ],
-      "general_variables": [
-        "signs_and_symptoms"
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
       ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
+    }
   },
   {
     "cohort_name": "EpiHealth",
@@ -763,6 +808,9 @@
     ],
     "pi_lead": "Lars Lind and S\u221a\u2202lve Elmst\u221a\u2022lh",
     "website": "https://www.epihealth.se/vad-ar-epihealth/",
+    "current_enrollment": 25000,
+    "target_enrollment": 25000,
+    "enrollment_period": "2011:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
@@ -770,30 +818,40 @@
       "phenotypic_clinical_data": true
     },
     "basic_cohort_attributes": {
-      "general_variables": [
-        "timeline"
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "data_type": [
-          "WGS"
+          "other"
         ],
         "general_variables": [
           "processing_method"
         ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
+      }
     },
     "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
       "medication": [
-        "prescription"
+        "associated_diseases"
       ],
-      "general_variables": [
-        "signs_and_symptoms"
-      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
       "socio_demographic_and_economic_characteristics": [
         "gender"
       ]
@@ -806,6 +864,9 @@
     ],
     "pi_lead": "Andres Metspalu",
     "website": "www.biobank.ee",
+    "current_enrollment": 200000,
+    "target_enrollment": 200000,
+    "enrollment_period": "2002:2018",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -817,30 +878,33 @@
         "data_collection_events"
       ],
       "demographic_data": [
-        "genders_studied_in_cohort"
+        "sexes_studied_in_cohort"
       ]
     },
     "biosample": {
       "sample_type": [
-        "saliva"
+        "stool"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "sample_size"
-        ],
         "data_type": [
-          "WGS"
+          "WES"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "medication": [
-        "drug_responses"
+      "diseases": [
+        "nervous_system"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
+      "medication": [
+        "administration_method"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
       ]
     }
   },
@@ -851,30 +915,43 @@
     ],
     "pi_lead": "Helj\u221a\u00a7-Marja Surcel",
     "website": "www.esis.fi",
+    "current_enrollment": 950000,
+    "target_enrollment": null,
+    "enrollment_period": "1983:2016",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": false
     },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
       ]
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "nervous_system"
+      "lifestyle_and_behaviours": [
+        "tobacco"
       ],
       "medication": [
-        "associated_diseases"
+        "drug_responses"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
       ]
     },
-    "survey_administration": [
-      "unique_identifiers"
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
     ]
   },
   {
@@ -889,38 +966,42 @@
     ],
     "pi_lead": "Anthony Swerdlow",
     "website": "http://www.breakthroughgenerations.org.uk/home",
+    "current_enrollment": 113000,
+    "target_enrollment": 100000,
+    "enrollment_period": "2003:2015",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
     "biosample": {
       "sample_type": [
-        "blood"
+        "saliva"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "associated_phenotype"
+        "data_type": [
+          "WES"
         ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
+      }
     },
     "questionnaire_survey_data": {
       "diseases": [
         "endocrine_nutritional_metabolic_disorders"
       ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      }
+    }
   },
   {
     "cohort_name": "Healthy Nevada",
@@ -929,6 +1010,9 @@
     ],
     "pi_lead": "Joe Grzymski",
     "website": "Healthynv.org",
+    "current_enrollment": 35000,
+    "target_enrollment": 250000,
+    "enrollment_period": "2016:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -943,24 +1027,27 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
+          "associated_disease"
         ],
         "data_type": [
-          "RNAseq_gene_expression"
+          "other"
         ]
-      },
-      "microbiology": [
-        "biosample_source_anatomical_location"
-      ]
+      }
     },
     "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "sleep"
+      "diseases": [
+        "digestive_system"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
       ]
-    }
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
   },
   {
     "cohort_name": "Israel Genome Project",
@@ -969,9 +1056,142 @@
     ],
     "pi_lead": "Gad Rennert",
     "website": "",
+    "current_enrollment": 140000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "RNAseq_gene_expression"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study (JPHC)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "http://epi.ncc.go.jp/en/jphc/",
+    "current_enrollment": 130000,
+    "target_enrollment": null,
+    "enrollment_period": "1990:1994",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "https://epi.ncc.go.jp/jphcnext/en/index.html",
+    "current_enrollment": 115000,
+    "target_enrollment": null,
+    "enrollment_period": "2011:2016",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_disease"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Kaiser Permanente Research Program on Genes, Environment, and Health",
+    "countries": [
+      "USA; Northern California"
+    ],
+    "pi_lead": "Catherine Schaefer",
+    "website": "http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx",
+    "current_enrollment": 210000,
+    "target_enrollment": 500000,
+    "enrollment_period": "2008: ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
@@ -982,9 +1202,6 @@
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ],
         "data_type": [
           "eQTL"
         ]
@@ -992,7 +1209,111 @@
     },
     "questionnaire_survey_data": {
       "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Korea Biobank Project",
+    "countries": [
+      "Republic of Korea"
+    ],
+    "pi_lead": "Jae-Pil Jeon and Changhoon Kim",
+    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346",
+    "current_enrollment": 830000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
         "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Korean Cancer Prevention Study (KCPS-II Biobank)",
+    "countries": [
+      "Korea"
+    ],
+    "pi_lead": "Sun Ha Jee",
+    "website": "",
+    "current_enrollment": 156701,
+    "target_enrollment": null,
+    "enrollment_period": "2004:2013",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
       ],
       "general_variables": [
         "life_stage_time_point"
@@ -1004,22 +1325,288 @@
         "anthropometry": [
           "height"
         ]
-      },
+      }
+    }
+  },
+  {
+    "cohort_name": "LifeGene (and sister cohort, EpiHealth)",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Nancy Pedersen",
+    "website": "https://www.lifegene.se/For-scientists/About-LifeGene/",
+    "current_enrollment": 51300,
+    "target_enrollment": 300000,
+    "enrollment_period": "2009:2016",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "posology"
+      ]
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging)",
+    "countries": [
+      "Europe (7)",
+      "Australia",
+      "USA"
+    ],
+    "pi_lead": "Terrence Simmons",
+    "website": "http://www.lifepathproject.eu/",
+    "current_enrollment": 235000,
+    "target_enrollment": null,
+    "enrollment_period": "Varies by cohort",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "prescription"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "age_birthdate"
+        "gender"
       ]
     }
   },
   {
-    "cohort_name": "Japan Public Health Center-based Prospective Study (JPHC)",
+    "cohort_name": "Malaysian Cohort",
     "countries": [
-      "Japan"
+      "Malaysia"
     ],
-    "pi_lead": "Shoichiro Tsugane",
-    "website": "http://epi.ncc.go.jp/en/jphc/",
+    "pi_lead": "Rahman Jamal",
+    "website": "http://mycohort.gov.my/site/",
+    "current_enrollment": 106527,
+    "target_enrollment": null,
+    "enrollment_period": "2007:2013",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Maule Cohort (MAUCO Study)",
+    "countries": [
+      "Chile"
+    ],
+    "pi_lead": "Catterina Ferreccio",
+    "website": "http://www.accdis.cl/eng/en/",
+    "current_enrollment": 9200,
+    "target_enrollment": 10000,
+    "enrollment_period": "2015:2018",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Mexico City Prospective Study",
+    "countries": [
+      "Mexico"
+    ],
+    "pi_lead": "Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, and Roberto Tapia-Conyer",
+    "website": "https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico",
+    "current_enrollment": 159755,
+    "target_enrollment": null,
+    "enrollment_period": "1998:2004",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ],
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Veteran Program",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Mike Gaziano",
+    "website": "http://www.research.va.gov/mvp/",
+    "current_enrollment": 785000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "2011:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "DNA_Genotyping"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Women Study",
+    "countries": [
+      "England",
+      "Scotland"
+    ],
+    "pi_lead": "Valerie Beral",
+    "website": "http://www.millionwomenstudy.org/introduction/",
+    "current_enrollment": 1320000,
+    "target_enrollment": null,
+    "enrollment_period": "1996:2001",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
@@ -1036,507 +1623,25 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
-        ],
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "medication": [
-        "associated_diseases"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT)",
-    "countries": [
-      "Japan"
-    ],
-    "pi_lead": "Shoichiro Tsugane",
-    "website": "https://epi.ncc.go.jp/jphcnext/en/index.html",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "location"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_disease"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "education"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Kaiser Permanente Research Program on Genes, Environment, and Health",
-    "countries": [
-      "USA; Northern California"
-    ],
-    "pi_lead": "Catherine Schaefer",
-    "website": "http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "genders_studied_in_cohort"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
-        ],
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "education"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "Korea Biobank Project",
-    "countries": [
-      "Republic of Korea"
-    ],
-    "pi_lead": "Jae-Pil Jeon and Changhoon Kim",
-    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "data_collection_events"
-      ],
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
-        ],
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "medication": [
-        "drug_responses"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      }
-    }
-  },
-  {
-    "cohort_name": "Korean Cancer Prevention Study (KCPS-II Biobank)",
-    "countries": [
-      "Korea"
-    ],
-    "pi_lead": "Sun Ha Jee",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Epigenetics"
-        ],
-        "general_variables": [
           "sample_size"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological"
+        "nervous_system"
       ],
       "general_variables": [
         "life_stage_time_point"
       ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ]
-    }
-  },
-  {
-    "cohort_name": "LifeGene (and sister cohort, EpiHealth)",
-    "countries": [
-      "Sweden"
-    ],
-    "pi_lead": "Nancy Pedersen",
-    "website": "https://www.lifegene.se/For-scientists/About-LifeGene/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ],
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "medication": [
-        "posology"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
-      ]
-    }
-  },
-  {
-    "cohort_name": "LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging)",
-    "countries": [
-      "Europe (7)",
-      "Australia",
-      "USA"
-    ],
-    "pi_lead": "Terrence Simmons",
-    "website": "http://www.lifepathproject.eu/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "blood"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "medication": [
-        "posology"
-      ]
-    },
-    "survey_administration": [
-      "date_and_time_related_information"
-    ]
-  },
-  {
-    "cohort_name": "Malaysian Cohort",
-    "countries": [
-      "Malaysia"
-    ],
-    "pi_lead": "Rahman Jamal",
-    "website": "http://mycohort.gov.my/site/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ],
-        "general_variables": [
-          "sample_size"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "medication": [
-        "administration_method"
-      ],
       "physiological_measurements": {
         "cirulation_and_respiration": [
-          "blood_pressure"
+          "heart_rate"
         ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "gender"
-      ]
+      }
     },
     "survey_administration": [
       "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Maule Cohort (MAUCO Study)",
-    "countries": [
-      "Chile"
-    ],
-    "pi_lead": "Catterina Ferreccio",
-    "website": "http://www.accdis.cl/eng/en/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Mexico City Prospective Study",
-    "countries": [
-      "Mexico"
-    ],
-    "pi_lead": "Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, and Roberto Tapia-Conyer",
-    "website": "https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ],
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "processing_method"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "gender"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Million Veteran Program",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Mike Gaziano",
-    "website": "http://www.research.va.gov/mvp/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "study_design"
-      ],
-      "demographic_data": [
-        "genders_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "eQTL"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "digestive_system"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
-      "general_variables": [
-        "signs_and_symptoms"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Million Women Study",
-    "countries": [
-      "England",
-      "Scotland"
-    ],
-    "pi_lead": "Valerie Beral",
-    "website": "http://www.millionwomenstudy.org/introduction/",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "saliva"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "medication": [
-        "drug_responses"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      }
-    },
-    "survey_administration": [
-      "consent_accessibility"
     ]
   },
   {
@@ -1546,6 +1651,9 @@
     ],
     "pi_lead": "Loic Le Marchand",
     "website": "https://www.uhcancercenter.org/mec",
+    "current_enrollment": 215251,
+    "target_enrollment": null,
+    "enrollment_period": "1993:1997",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -1558,31 +1666,22 @@
       ]
     },
     "biosample": {
-      "general_variables": [
-        "storage_method"
+      "sample_type": [
+        "urine"
       ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Sequence_variants"
-        ]
-      }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "blood_related_disorders"
+        "oncological"
       ],
-      "general_variables": [
-        "physician_practitioner_info"
+      "lifestyle_and_behaviours": [
+        "sleep"
       ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
+      "medication": [
+        "posology"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
+        "genealogy"
       ]
     },
     "survey_administration": [
@@ -1596,155 +1695,9 @@
     ],
     "pi_lead": "David H Ledbetter",
     "website": "https://www.geisinger.org/mycode",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "nutrition"
-      ],
-      "medication": [
-        "associated_diseases"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
-    },
-    "survey_administration": [
-      "consent_accessibility"
-    ]
-  },
-  {
-    "cohort_name": "Netherlands Twin Registry",
-    "countries": [
-      "Netherlands"
-    ],
-    "pi_lead": "Dorret Boomsma",
-    "website": "http://www.tweelingenregister.org/en/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "availability"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "endocrine_nutritional_metabolic_disorders"
-      ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ],
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      }
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Newfoundland 100K Genome Project / Sequence Bio",
-    "countries": [
-      "Canada (Province of Newfoundland and Labrador)"
-    ],
-    "pi_lead": "Michael Phillips",
-    "website": "https://www.sequencebio.com/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
-        ],
-        "data_type": [
-          "WES"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "medication": [
-        "prescription"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "NHS (Nurses' Health Study, NCI)",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Meir Stampfer, Rulla Tamimi",
-    "website": "www.nurseshealthstudy.org",
+    "current_enrollment": 252160,
+    "target_enrollment": 250000,
+    "enrollment_period": "2007:ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -1753,8 +1706,184 @@
     },
     "basic_cohort_attributes": {
       "general_variables": [
-        "data_collection_events"
+        "timeline"
       ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Netherlands Twin Registry",
+    "countries": [
+      "Netherlands"
+    ],
+    "pi_lead": "Dorret Boomsma",
+    "website": "http://www.tweelingenregister.org/en/",
+    "current_enrollment": 275000,
+    "target_enrollment": null,
+    "enrollment_period": "1987:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Newfoundland 100K Genome Project / Sequence Bio",
+    "countries": [
+      "Canada (Province of Newfoundland and Labrador)"
+    ],
+    "pi_lead": "Michael Phillips",
+    "website": "https://www.sequencebio.com/",
+    "current_enrollment": 520000,
+    "target_enrollment": null,
+    "enrollment_period": "2018:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "NHS (Nurses' Health Study, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Meir Stampfer, Rulla Tamimi",
+    "website": "www.nurseshealthstudy.org",
+    "current_enrollment": 121700,
+    "target_enrollment": null,
+    "enrollment_period": "1976:1976",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "NHSII (Nurses' Health Study II, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Walter Willett, Heather Eliassen",
+    "website": "www.nurseshealthstudy.org",
+    "current_enrollment": 116430,
+    "target_enrollment": null,
+    "enrollment_period": "1989:1989",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
     },
     "laboratory_measures": {
       "genomics": {
@@ -1764,15 +1893,9 @@
         "data_type": [
           "WGS"
         ]
-      },
-      "microbiology": [
-        "biosample_source_anatomical_location"
-      ]
+      }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
       "medication": [
         "prescription"
       ],
@@ -1780,57 +1903,9 @@
         "cirulation_and_respiration": [
           "blood_pressure"
         ]
-      }
-    },
-    "survey_administration": [
-      "consent_accessibility"
-    ]
-  },
-  {
-    "cohort_name": "NHSII (Nurses' Health Study II, NCI)",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Walter Willett, Heather Eliassen",
-    "website": "www.nurseshealthstudy.org",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "aims_and_objectives"
-      ]
-    },
-    "biosample": {
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
-        "data_type": [
-          "WES"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "nutrition"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "general_variables": [
-        "signs_and_symptoms"
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
       ]
     }
   },
@@ -1841,152 +1916,31 @@
     ],
     "pi_lead": "Rennert Gad",
     "website": "",
+    "current_enrollment": 40000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "data_collection_events"
+    "biosample": {
+      "sample_type": [
+        "urine"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "sample_size"
+          "available_data_formats"
         ],
         "data_type": [
-          "RNAseq_gene_expression"
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
-      "diseases": [
-        "circulatory_system"
-      ],
-      "medication": [
-        "posology"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "Northern Sweden Health and Disease Study",
-    "countries": [
-      "Sweden"
-    ],
-    "pi_lead": "Beatrice Melin",
-    "website": "http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "medication": [
-        "posology"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "birthplace"
-      ]
-    },
-    "survey_administration": [
-      "date_and_time_related_information"
-    ]
-  },
-  {
-    "cohort_name": "Norwegian Family Based Life Course Study",
-    "countries": [
-      "Norway"
-    ],
-    "pi_lead": "\u221a\u00f2yvind N\u221a\u00b6ss",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ],
-      "population_data": [
-        "criteria_for_enrollment_and_recruitment_procedures"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "medication": [
-        "posology"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Norwegian Mother and Child Cohort Study (MoBa)",
-    "countries": [
-      "Norway"
-    ],
-    "pi_lead": "Per Magnus",
-    "website": "https://www.fhi.no/en/studies/moba/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Sequence_variants"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "nervous_system"
-      ],
       "general_variables": [
         "life_stage_time_point"
       ],
@@ -1999,7 +1953,155 @@
         ]
       },
       "socio_demographic_and_economic_characteristics": [
-        "age_birthdate"
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Northern Sweden Health and Disease Study",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Beatrice Melin",
+    "website": "http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/",
+    "current_enrollment": 135000,
+    "target_enrollment": null,
+    "enrollment_period": "1985 : ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Norwegian Family Based Life Course Study",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "\u221a\u00f2yvind N\u221a\u00b6ss",
+    "website": "",
+    "current_enrollment": 5266270,
+    "target_enrollment": null,
+    "enrollment_period": "1960:2011",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Norwegian Mother and Child Cohort Study (MoBa)",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "Per Magnus",
+    "website": "https://www.fhi.no/en/studies/moba/",
+    "current_enrollment": 284000,
+    "target_enrollment": null,
+    "enrollment_period": "1999:2008",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ],
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WES"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "circulatory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
       ]
     }
   },
@@ -2010,39 +2112,46 @@
     ],
     "pi_lead": "Danish Salaheen",
     "website": "https://www.cncdpk.com/page/Pakistan-Genomic-Resource-(PGR)",
+    "current_enrollment": 150000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": false,
       "biospecimens": false,
       "phenotypic_clinical_data": false
     },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
-      ],
-      "general_variables": [
-        "timeline"
-      ]
-    },
     "biosample": {
-      "sample_type": [
-        "saliva"
+      "general_variables": [
+        "storage_method"
       ]
     },
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_medication"
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "education"
+        "residence"
       ]
     },
-    "survey_administration": [
-      "date_and_time_related_information"
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
     ]
   },
   {
@@ -2052,11 +2161,22 @@
     ],
     "pi_lead": "Reza Malekzadeh,  Hossein Poustchi,  Farin Kamangar,  Arash Etemadi",
     "website": "http://persiancohort.com",
+    "current_enrollment": 180000,
+    "target_enrollment": null,
+    "enrollment_period": "2014:ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "population_data": [
+        "location"
+      ]
     },
     "biosample": {
       "sample_type": [
@@ -2065,20 +2185,23 @@
     },
     "laboratory_measures": {
       "genomics": {
+        "data_type": [
+          "RNAseq_gene_expression"
+        ],
         "general_variables": [
           "processing_method"
-        ],
-        "data_type": [
-          "WES"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "respiratory_system"
+        "blood_related_disorders"
       ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
       ]
     }
   },
@@ -2089,6 +2212,9 @@
     ],
     "pi_lead": "Paul Pinsky and Neal Freedman",
     "website": "http://prevention.cancer.gov/major-programs/prostate-lung-colorectal",
+    "current_enrollment": 154907,
+    "target_enrollment": null,
+    "enrollment_period": "1993:2001",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
@@ -2098,7 +2224,7 @@
     "laboratory_measures": {
       "genomics": {
         "general_variables": [
-          "associated_disease"
+          "availability"
         ],
         "data_type": [
           "eQTL"
@@ -2106,11 +2232,19 @@
       }
     },
     "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "tobacco"
+      "diseases": [
+        "mental_and_behaviour_disorders"
       ],
-      "medication": [
-        "prescription"
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
       ]
     }
   },
@@ -2121,6 +2255,9 @@
     ],
     "pi_lead": "Hamdi Mbarek",
     "website": "https://qatargenome.org.qa/",
+    "current_enrollment": 15000,
+    "target_enrollment": 300000,
+    "enrollment_period": "2015: ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -2128,29 +2265,27 @@
       "phenotypic_clinical_data": true
     },
     "basic_cohort_attributes": {
-      "population_data": [
-        "num_participants"
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
       ]
     },
     "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "sample_size"
-        ],
-        "data_type": [
-          "eQTL"
-        ]
-      },
       "microbiology": [
-        "microbial_data"
+        "biosample_source_anatomical_location"
       ]
     },
     "questionnaire_survey_data": {
-      "non_pharmacological_interventions": [
-        "surgical_interventions"
+      "diseases": [
+        "oncological"
       ],
-      "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
       ]
     }
   },
@@ -2161,6 +2296,9 @@
     ],
     "pi_lead": "Sultan AlSudiri and Malak Abedalthagafi",
     "website": "http://shgp.kacst.edu.sa/site/",
+    "current_enrollment": 100000,
+    "target_enrollment": null,
+    "enrollment_period": "",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -2168,34 +2306,34 @@
       "phenotypic_clinical_data": false
     },
     "basic_cohort_attributes": {
-      "demographic_data": [
-        "genders_studied_in_cohort"
+      "population_data": [
+        "num_participants"
       ]
     },
     "laboratory_measures": {
       "genomics": {
-        "general_variables": [
-          "available_data_formats"
-        ],
         "data_type": [
-          "WES"
+          "eQTL"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "respiratory_system"
+        "circulatory_system"
       ],
       "lifestyle_and_behaviours": [
-        "sleep"
+        "alcohol"
       ],
-      "medication": [
-        "prescription"
+      "general_variables": [
+        "signs_and_symptoms"
       ],
       "socio_demographic_and_economic_characteristics": [
-        "birthplace"
+        "ethnicity_race"
       ]
-    }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
   },
   {
     "cohort_name": "Saudi National Biobank",
@@ -2204,45 +2342,9 @@
     ],
     "pi_lead": "Ada Al-Qunaibet",
     "website": "http://www.ksau-hs.edu.sa/English/Research/Pages/KAIMRC.aspx",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "location"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "physical_activity"
-      ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "height"
-        ],
-        "cirulation_and_respiration": [
-          "blood_pressure"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Shanghai Men and Women's Health Study (2 cohorts)",
-    "countries": [
-      "Shanghai",
-      "China"
-    ],
-    "pi_lead": "Wei Zheng",
-    "website": "http://www.mc.vanderbilt.edu/swhs-smhs/",
+    "current_enrollment": 2000,
+    "target_enrollment": null,
+    "enrollment_period": ":ongoing",
     "available_data_types": {
       "genomic_data": false,
       "environmental_data": false,
@@ -2251,351 +2353,8 @@
     },
     "basic_cohort_attributes": {
       "general_variables": [
-        "data_collection_events"
+        "aims_and_objectives"
       ]
-    },
-    "biosample": {
-      "sample_type": [
-        "blood"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "sample_size"
-        ],
-        "data_type": [
-          "eQTL"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "medication": [
-        "posology"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Singapore National Precision Medicine Program",
-    "countries": [
-      "Singapore"
-    ],
-    "pi_lead": "Patrick Tan and E Shyong Tai",
-    "website": "",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "age_range"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "lifestyle_and_behaviours": [
-        "sleep"
-      ],
-      "medication": [
-        "administration_method"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "residence"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "South(east) Asian Cohorts - NETWORK",
-    "countries": [
-      "Bangladesh",
-      "Malaysia",
-      "Sri Lanka"
-    ],
-    "pi_lead": "Rajiv Chowdhury",
-    "website": "http://www.phpc.cam.ac.uk/ceu/international-vascular-health/believe/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "WGS"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "respiratory_system"
-      ],
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
-      ]
-    },
-    "survey_administration": [
-      "unique_identifiers"
-    ]
-  },
-  {
-    "cohort_name": "Taiwan Biobank",
-    "countries": [
-      "Taiwan"
-    ],
-    "pi_lead": "Te-Chang Lee and Chung-ke Chang",
-    "website": "https://www.twbiobank.org.tw/new_web/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "population_data": [
-        "location"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "saliva"
-      ]
-    },
-    "laboratory_measures": {
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "tobacco"
-      ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "genealogy"
-      ]
-    },
-    "survey_administration": [
-      "consent_accessibility"
-    ]
-  },
-  {
-    "cohort_name": "U.S. Precision Medicine Initiative / All of Us",
-    "countries": [
-      "USA"
-    ],
-    "pi_lead": "Stephanie Devaney",
-    "website": "https://allofus.nih.gov/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ],
-      "general_variables": [
-        "timeline"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "stool"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_cell_type_tissue_type_biosample"
-        ],
-        "data_type": [
-          "DNA_Genotyping"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "lifestyle_and_behaviours": [
-        "alcohol"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
-      ]
-    },
-    "statistics": [
-      "summary_statistics_for_additional_data_from_federated_sources"
-    ]
-  },
-  {
-    "cohort_name": "UK Biobank",
-    "countries": [
-      "England",
-      "Scotland",
-      "Wales"
-    ],
-    "pi_lead": "Rory Collins",
-    "website": "http://www.ukbiobank.ac.uk/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "demographic_data": [
-        "sexes_studied_in_cohort"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ],
-      "general_variables": [
-        "storage_method"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "data_type": [
-          "Microbiome_markers"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "oncological"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "education"
-      ]
-    }
-  },
-  {
-    "cohort_name": "UK Blood Donor Cohorts",
-    "countries": [
-      "UK"
-    ],
-    "pi_lead": "Emanuele Di Angelantonio and John Danesh",
-    "website": "http://www.intervalstudy.org.uk/",
-    "available_data_types": {
-      "genomic_data": true,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "basic_cohort_attributes": {
-      "general_variables": [
-        "study_design"
-      ]
-    },
-    "biosample": {
-      "sample_type": [
-        "urine"
-      ]
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_medication"
-        ],
-        "data_type": [
-          "other"
-        ]
-      }
-    },
-    "questionnaire_survey_data": {
-      "diseases": [
-        "blood_related_disorders"
-      ],
-      "medication": [
-        "associated_diseases"
-      ],
-      "general_variables": [
-        "physician_practitioner_info"
-      ],
-      "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
-      ]
-    }
-  },
-  {
-    "cohort_name": "UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women's Cohort UKLWC",
-    "countries": [
-      "England",
-      "Wales",
-      "Northern Ireland"
-    ],
-    "pi_lead": "Usha Menon",
-    "website": "http://www.isrctn.com/ISRCTN22488978",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": false,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
-    },
-    "laboratory_measures": {
-      "genomics": {
-        "general_variables": [
-          "associated_phenotype"
-        ]
-      },
-      "microbiology": [
-        "microbial_data"
-      ]
-    },
-    "questionnaire_survey_data": {
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
-      "socio_demographic_and_economic_characteristics": [
-        "biological_sex"
-      ]
-    }
-  },
-  {
-    "cohort_name": "Vorarlberg Health Monitoring and Promotion Programme (VHM&PP)",
-    "countries": [
-      "Austria"
-    ],
-    "pi_lead": "Hans Concin, Gabriele Nagel, Hanno Ulmer",
-    "website": "http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs",
-    "available_data_types": {
-      "genomic_data": false,
-      "environmental_data": true,
-      "biospecimens": true,
-      "phenotypic_clinical_data": true
     },
     "biosample": {
       "sample_type": [
@@ -2610,25 +2369,429 @@
       }
     },
     "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Shanghai Men and Women's Health Study (2 cohorts)",
+    "countries": [
+      "Shanghai",
+      "China"
+    ],
+    "pi_lead": "Wei Zheng",
+    "website": "http://www.mc.vanderbilt.edu/swhs-smhs/",
+    "current_enrollment": 136000,
+    "target_enrollment": null,
+    "enrollment_period": "1996:2000",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Singapore National Precision Medicine Program",
+    "countries": [
+      "Singapore"
+    ],
+    "pi_lead": "Patrick Tan and E Shyong Tai",
+    "website": "",
+    "current_enrollment": 10000,
+    "target_enrollment": 1000000,
+    "enrollment_period": "10 year program",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
       "diseases": [
-        "nervous_system"
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "South(east) Asian Cohorts - NETWORK",
+    "countries": [
+      "Bangladesh",
+      "Malaysia",
+      "Sri Lanka"
+    ],
+    "pi_lead": "Rajiv Chowdhury",
+    "website": "http://www.phpc.cam.ac.uk/ceu/international-vascular-health/believe/",
+    "current_enrollment": 75000,
+    "target_enrollment": 150000,
+    "enrollment_period": "2010:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Taiwan Biobank",
+    "countries": [
+      "Taiwan"
+    ],
+    "pi_lead": "Te-Chang Lee and Chung-ke Chang",
+    "website": "https://www.twbiobank.org.tw/new_web/",
+    "current_enrollment": 118548,
+    "target_enrollment": 200000,
+    "enrollment_period": "2012:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "medication": [
+        "posology"
+      ]
+    }
+  },
+  {
+    "cohort_name": "U.S. Precision Medicine Initiative / All of Us",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Stephanie Devaney",
+    "website": "https://allofus.nih.gov/",
+    "current_enrollment": 191105,
+    "target_enrollment": 1000000,
+    "enrollment_period": "2018:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
       ],
       "lifestyle_and_behaviours": [
         "sleep"
       ],
       "medication": [
-        "prescription"
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UK Biobank",
+    "countries": [
+      "England",
+      "Scotland",
+      "Wales"
+    ],
+    "pi_lead": "Rory Collins",
+    "website": "http://www.ukbiobank.ac.uk/",
+    "current_enrollment": 502713,
+    "target_enrollment": 500000,
+    "enrollment_period": "2006:2010",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UK Blood Donor Cohorts",
+    "countries": [
+      "UK"
+    ],
+    "pi_lead": "Emanuele Di Angelantonio and John Danesh",
+    "website": "http://www.intervalstudy.org.uk/",
+    "current_enrollment": 100000,
+    "target_enrollment": 350000,
+    "enrollment_period": "2012:ongoing",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "mental_and_behaviour_disorders"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women\u201a\u00c4\u00f4s Cohort UKLWC",
+    "countries": [
+      "England",
+      "Wales",
+      "Northern Ireland"
+    ],
+    "pi_lead": "Usha Menon",
+    "website": "http://www.isrctn.com/ISRCTN22488978",
+    "current_enrollment": 202638,
+    "target_enrollment": null,
+    "enrollment_period": "2001:2005",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Vorarlberg Health Monitoring and Promotion Programme (VHM&PP)",
+    "countries": [
+      "Austria"
+    ],
+    "pi_lead": "Hans Concin, Gabriele Nagel, Hanno Ulmer",
+    "website": "http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs",
+    "current_enrollment": 180000,
+    "target_enrollment": null,
+    "enrollment_period": "1985:2014",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
       ],
       "general_variables": [
         "physician_practitioner_info"
       ],
-      "physiological_measurements": {
-        "anthropometry": [
-          "weight"
-        ]
-      },
       "socio_demographic_and_economic_characteristics": [
-        "ethnicity_race"
+        "education"
       ]
     }
   },
@@ -2639,43 +2802,49 @@
     ],
     "pi_lead": "Garnet Anderson",
     "website": "https://deino.whiops.org/go/www.whi.org~ssl/SitePages/WHI%20Home.aspx",
+    "current_enrollment": 161808,
+    "target_enrollment": null,
+    "enrollment_period": "1993:1998",
     "available_data_types": {
       "genomic_data": true,
       "environmental_data": true,
       "biospecimens": true,
       "phenotypic_clinical_data": true
     },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
     "laboratory_measures": {
       "genomics": {
         "data_type": [
-          "other"
-        ],
-        "general_variables": [
-          "sample_size"
+          "RNAseq_gene_expression"
         ]
       }
     },
     "questionnaire_survey_data": {
       "diseases": [
-        "oncological"
+        "nervous_system"
       ],
-      "lifestyle_and_behaviours": [
-        "nutrition"
+      "medication": [
+        "prescription"
       ],
       "non_pharmacological_interventions": [
         "surgical_interventions"
       ],
-      "physiological_measurements": {
-        "cirulation_and_respiration": [
-          "heart_rate"
-        ]
-      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
       "socio_demographic_and_economic_characteristics": [
-        "family_and_household_structure"
+        "birthplace"
       ]
     },
     "survey_administration": [
-      "date_and_time_related_information"
+      "consent_accessibility"
     ]
   }
 ]

--- a/data/random-data.json
+++ b/data/random-data.json
@@ -1,0 +1,2681 @@
+[
+  {
+    "cohort_name": "23andMe",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Joyce Tung",
+    "website": "https://research.23andme.com/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "45 and Up Study",
+    "countries": [
+      "Australia"
+    ],
+    "pi_lead": "Martin McNamara",
+    "website": "https://www.saxinstitute.org.au/our-work/45-up-study/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ],
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Apolipoprotein MORtality RISk study (AMORIS)",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Goran Walldius",
+    "website": "http://amoriscohort.imm.ki.se",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Biobank Japan",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Yoshinori Murakami",
+    "website": "https://biobankjp.org/english/index.html",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "Metagenomics"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "BioVU Vanderbilt",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Dan Roden",
+    "website": "https://victr.vanderbilt.edu/pub/biovu/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "Metagenomics"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Canadian Partnership for Tomorrow Project (CPTP)",
+    "countries": [
+      "Canada"
+    ],
+    "pi_lead": "Philip Awadalla",
+    "website": "http://www.partnershipfortomorrow.ca",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II (CPS-II)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/index",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": false,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Cancer Prevention Study II Nutrition Cohort",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Susan Gapstur",
+    "website": "http://www.cancer.org/research/researchtopreventcancer/currentcancerpreventionstudies/cancer-prevention-study",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Children's Hospital of Philadelphia (CHOP) Biorepository",
+    "countries": [
+      "USA",
+      "Europe",
+      "South America",
+      "Canada",
+      "Saudi Arabia",
+      "Australia"
+    ],
+    "pi_lead": "Hakon Hakonarson",
+    "website": "https://caglab.org/index.php/for-researchers/biorepository.html",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "China Kadoorie Biobank",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Zhengming Chen and Liming Li",
+    "website": "http://www.ckbiobank.org/site/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    }
+  },
+  {
+    "cohort_name": "China PEACE (Patient-centered Evaluative Assessment of Cardiac Events) Million Persons Project",
+    "countries": [
+      "China"
+    ],
+    "pi_lead": "Linxin Jiang",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      }
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Constances Project",
+    "countries": [
+      "France"
+    ],
+    "pi_lead": "Marie Zins",
+    "website": "http://www.constances.fr/index_EN.php",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Danish National Birth Cohort",
+    "countries": [
+      "Denmark"
+    ],
+    "pi_lead": "Mads Melbye",
+    "website": "dnbc.dk",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ],
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "East London Genes and Health",
+    "countries": [
+      "UK"
+    ],
+    "pi_lead": "David van Heel",
+    "website": "http://www.genesandhealth.org/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "ELSA-Brasil",
+    "countries": [
+      "Brazil: six cities"
+    ],
+    "pi_lead": "Paulo A. Lotufo",
+    "website": "www.elsa.org.br",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Environmental influences on Child Health Outcomes (ECHO) Cohort",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Matt Gillman",
+    "website": "https://www.nih.gov/echo",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "EPIC (European Prospective Investigation into Cancer, Chronic Diseases, Nutrition and Lifestyle)",
+    "countries": [
+      "UK",
+      "Italy",
+      "France",
+      "Germany",
+      "Norway",
+      "Netherlands",
+      "Denmark",
+      "Spain",
+      "Greece",
+      "Sweden"
+    ],
+    "pi_lead": "Elio Riboli, Paul Brennan, and Marc Gunter",
+    "website": "http://epic.iarc.fr/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ],
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "administration_method"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "EpiHealth",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Lars Lind and S\u221a\u2202lve Elmst\u221a\u2022lh",
+    "website": "https://www.epihealth.se/vad-ar-epihealth/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ],
+        "general_variables": [
+          "processing_method"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Estonian Genome Project",
+    "countries": [
+      "Estonia"
+    ],
+    "pi_lead": "Andres Metspalu",
+    "website": "www.biobank.ee",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "drug_responses"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Finnish Maternity Cohort Serum Bank",
+    "countries": [
+      "Finland"
+    ],
+    "pi_lead": "Helj\u221a\u00a7-Marja Surcel",
+    "website": "www.esis.fi",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": false
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Generations Study (GS)",
+    "countries": [
+      "England",
+      "Scotland",
+      "Wales",
+      "Northern Ireland",
+      "Isle of Man",
+      "Channel Islands"
+    ],
+    "pi_lead": "Anthony Swerdlow",
+    "website": "http://www.breakthroughgenerations.org.uk/home",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Healthy Nevada",
+    "countries": [
+      "US"
+    ],
+    "pi_lead": "Joe Grzymski",
+    "website": "Healthynv.org",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": false,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Israel Genome Project",
+    "countries": [
+      "Israel"
+    ],
+    "pi_lead": "Gad Rennert",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study (JPHC)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "http://epi.ncc.go.jp/en/jphc/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Japan Public Health Center-based Prospective Study for the Next Generation (JPHC-NEXT)",
+    "countries": [
+      "Japan"
+    ],
+    "pi_lead": "Shoichiro Tsugane",
+    "website": "https://epi.ncc.go.jp/jphcnext/en/index.html",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_disease"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Kaiser Permanente Research Program on Genes, Environment, and Health",
+    "countries": [
+      "USA; Northern California"
+    ],
+    "pi_lead": "Catherine Schaefer",
+    "website": "http://www.dor.kaiser.org/external/DORExternal/rpgeh/index.aspx",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Korea Biobank Project",
+    "countries": [
+      "Republic of Korea"
+    ],
+    "pi_lead": "Jae-Pil Jeon and Changhoon Kim",
+    "website": "http://www.nih.go.kr/NIH/eng/contents/NihEngContentView.jsp?cid=65660&menuIds=HOME004-MNU2210-MNU2327-MNU2346",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ],
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      }
+    }
+  },
+  {
+    "cohort_name": "Korean Cancer Prevention Study (KCPS-II Biobank)",
+    "countries": [
+      "Korea"
+    ],
+    "pi_lead": "Sun Ha Jee",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Epigenetics"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ]
+    }
+  },
+  {
+    "cohort_name": "LifeGene (and sister cohort, EpiHealth)",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Nancy Pedersen",
+    "website": "https://www.lifegene.se/For-scientists/About-LifeGene/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "LIFEPATH (Lifecourse biological pathways underlying social differences in healthy aging)",
+    "countries": [
+      "Europe (7)",
+      "Australia",
+      "USA"
+    ],
+    "pi_lead": "Terrence Simmons",
+    "website": "http://www.lifepathproject.eu/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "posology"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Malaysian Cohort",
+    "countries": [
+      "Malaysia"
+    ],
+    "pi_lead": "Rahman Jamal",
+    "website": "http://mycohort.gov.my/site/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Maule Cohort (MAUCO Study)",
+    "countries": [
+      "Chile"
+    ],
+    "pi_lead": "Catterina Ferreccio",
+    "website": "http://www.accdis.cl/eng/en/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Mexico City Prospective Study",
+    "countries": [
+      "Mexico"
+    ],
+    "pi_lead": "Jesus Alegre, Jonathan Emberson, Pablo Kuri-Morales, and Roberto Tapia-Conyer",
+    "website": "https://www.ctsu.ox.ac.uk/research/prospective-blood-based-study-of-150-000-individuals-in-mexico",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "gender"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Veteran Program",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Mike Gaziano",
+    "website": "http://www.research.va.gov/mvp/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ],
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "digestive_system"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "general_variables": [
+        "signs_and_symptoms"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Million Women Study",
+    "countries": [
+      "England",
+      "Scotland"
+    ],
+    "pi_lead": "Valerie Beral",
+    "website": "http://www.millionwomenstudy.org/introduction/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "medication": [
+        "drug_responses"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      }
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "Multiethnic Cohort Study (MEC, NCI)",
+    "countries": [
+      "USA (Hawaii; California)"
+    ],
+    "pi_lead": "Loic Le Marchand",
+    "website": "https://www.uhcancercenter.org/mec",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "MyCode Community Health Initiative",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "David H Ledbetter",
+    "website": "https://www.geisinger.org/mycode",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "Netherlands Twin Registry",
+    "countries": [
+      "Netherlands"
+    ],
+    "pi_lead": "Dorret Boomsma",
+    "website": "http://www.tweelingenregister.org/en/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "endocrine_nutritional_metabolic_disorders"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ],
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      }
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Newfoundland 100K Genome Project / Sequence Bio",
+    "countries": [
+      "Canada (Province of Newfoundland and Labrador)"
+    ],
+    "pi_lead": "Michael Phillips",
+    "website": "https://www.sequencebio.com/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "NHS (Nurses' Health Study, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Meir Stampfer, Rulla Tamimi",
+    "website": "www.nurseshealthstudy.org",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ],
+        "data_type": [
+          "WGS"
+        ]
+      },
+      "microbiology": [
+        "biosample_source_anatomical_location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      }
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "NHSII (Nurses' Health Study II, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Walter Willett, Heather Eliassen",
+    "website": "www.nurseshealthstudy.org",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "aims_and_objectives"
+      ]
+    },
+    "biosample": {
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "general_variables": [
+        "signs_and_symptoms"
+      ]
+    }
+  },
+  {
+    "cohort_name": "NICCC",
+    "countries": [
+      ""
+    ],
+    "pi_lead": "Rennert Gad",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "RNAseq_gene_expression"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "circulatory_system"
+      ],
+      "medication": [
+        "posology"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "Northern Sweden Health and Disease Study",
+    "countries": [
+      "Sweden"
+    ],
+    "pi_lead": "Beatrice Melin",
+    "website": "http://www.biobank.umu.se/biobank/biobank---for-researchers/biobank-research---sample-collections/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "posology"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "Norwegian Family Based Life Course Study",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "\u221a\u00f2yvind N\u221a\u00b6ss",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ],
+      "population_data": [
+        "criteria_for_enrollment_and_recruitment_procedures"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "posology"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Norwegian Mother and Child Cohort Study (MoBa)",
+    "countries": [
+      "Norway"
+    ],
+    "pi_lead": "Per Magnus",
+    "website": "https://www.fhi.no/en/studies/moba/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Sequence_variants"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "general_variables": [
+        "life_stage_time_point"
+      ],
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "age_birthdate"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Pakistan Genomic Resource (PGR)",
+    "countries": [
+      "Pakistan"
+    ],
+    "pi_lead": "Danish Salaheen",
+    "website": "https://www.cncdpk.com/page/Pakistan-Genomic-Resource-(PGR)",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": false,
+      "phenotypic_clinical_data": false
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  },
+  {
+    "cohort_name": "PERSIAN Cohort Study",
+    "countries": [
+      "Iran"
+    ],
+    "pi_lead": "Reza Malekzadeh,  Hossein Poustchi,  Farin Kamangar,  Arash Etemadi",
+    "website": "http://persiancohort.com",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "processing_method"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ]
+    }
+  },
+  {
+    "cohort_name": "PLCO (Prostate, Lung, Colorectal and Ovarian Cancer Screening Trial, NCI)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Paul Pinsky and Neal Freedman",
+    "website": "http://prevention.cancer.gov/major-programs/prostate-lung-colorectal",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_disease"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "medication": [
+        "prescription"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Qatar Genome Project",
+    "countries": [
+      "Qatar"
+    ],
+    "pi_lead": "Hamdi Mbarek",
+    "website": "https://qatargenome.org.qa/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "num_participants"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Saudi Human Genome Program",
+    "countries": [
+      "Saudi Arabia"
+    ],
+    "pi_lead": "Sultan AlSudiri and Malak Abedalthagafi",
+    "website": "http://shgp.kacst.edu.sa/site/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": false
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "genders_studied_in_cohort"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "available_data_formats"
+        ],
+        "data_type": [
+          "WES"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "birthplace"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Saudi National Biobank",
+    "countries": [
+      "Saudi Arabia"
+    ],
+    "pi_lead": "Ada Al-Qunaibet",
+    "website": "http://www.ksau-hs.edu.sa/English/Research/Pages/KAIMRC.aspx",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "physical_activity"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "height"
+        ],
+        "cirulation_and_respiration": [
+          "blood_pressure"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Shanghai Men and Women's Health Study (2 cohorts)",
+    "countries": [
+      "Shanghai",
+      "China"
+    ],
+    "pi_lead": "Wei Zheng",
+    "website": "http://www.mc.vanderbilt.edu/swhs-smhs/",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "data_collection_events"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "blood"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "sample_size"
+        ],
+        "data_type": [
+          "eQTL"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "medication": [
+        "posology"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Singapore National Precision Medicine Program",
+    "countries": [
+      "Singapore"
+    ],
+    "pi_lead": "Patrick Tan and E Shyong Tai",
+    "website": "",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "age_range"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "administration_method"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "residence"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "South(east) Asian Cohorts - NETWORK",
+    "countries": [
+      "Bangladesh",
+      "Malaysia",
+      "Sri Lanka"
+    ],
+    "pi_lead": "Rajiv Chowdhury",
+    "website": "http://www.phpc.cam.ac.uk/ceu/international-vascular-health/believe/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "WGS"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "respiratory_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    },
+    "survey_administration": [
+      "unique_identifiers"
+    ]
+  },
+  {
+    "cohort_name": "Taiwan Biobank",
+    "countries": [
+      "Taiwan"
+    ],
+    "pi_lead": "Te-Chang Lee and Chung-ke Chang",
+    "website": "https://www.twbiobank.org.tw/new_web/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "population_data": [
+        "location"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "saliva"
+      ]
+    },
+    "laboratory_measures": {
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "tobacco"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "genealogy"
+      ]
+    },
+    "survey_administration": [
+      "consent_accessibility"
+    ]
+  },
+  {
+    "cohort_name": "U.S. Precision Medicine Initiative / All of Us",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Stephanie Devaney",
+    "website": "https://allofus.nih.gov/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ],
+      "general_variables": [
+        "timeline"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "stool"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_cell_type_tissue_type_biosample"
+        ],
+        "data_type": [
+          "DNA_Genotyping"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "lifestyle_and_behaviours": [
+        "alcohol"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    },
+    "statistics": [
+      "summary_statistics_for_additional_data_from_federated_sources"
+    ]
+  },
+  {
+    "cohort_name": "UK Biobank",
+    "countries": [
+      "England",
+      "Scotland",
+      "Wales"
+    ],
+    "pi_lead": "Rory Collins",
+    "website": "http://www.ukbiobank.ac.uk/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "demographic_data": [
+        "sexes_studied_in_cohort"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ],
+      "general_variables": [
+        "storage_method"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "Microbiome_markers"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "education"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UK Blood Donor Cohorts",
+    "countries": [
+      "UK"
+    ],
+    "pi_lead": "Emanuele Di Angelantonio and John Danesh",
+    "website": "http://www.intervalstudy.org.uk/",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "basic_cohort_attributes": {
+      "general_variables": [
+        "study_design"
+      ]
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_medication"
+        ],
+        "data_type": [
+          "other"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "blood_related_disorders"
+      ],
+      "medication": [
+        "associated_diseases"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "UKLWC (UK Collaborative Trial of Ovarian Cancer Screening) Longitudinal Women's Cohort UKLWC",
+    "countries": [
+      "England",
+      "Wales",
+      "Northern Ireland"
+    ],
+    "pi_lead": "Usha Menon",
+    "website": "http://www.isrctn.com/ISRCTN22488978",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": false,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "associated_phenotype"
+        ]
+      },
+      "microbiology": [
+        "microbial_data"
+      ]
+    },
+    "questionnaire_survey_data": {
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "biological_sex"
+      ]
+    }
+  },
+  {
+    "cohort_name": "Vorarlberg Health Monitoring and Promotion Programme (VHM&PP)",
+    "countries": [
+      "Austria"
+    ],
+    "pi_lead": "Hans Concin, Gabriele Nagel, Hanno Ulmer",
+    "website": "http://www.ucl.ac.uk/womens-health/research/womens-cancer/gynaecological-cancer-research-centre/ukctocs",
+    "available_data_types": {
+      "genomic_data": false,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "biosample": {
+      "sample_type": [
+        "urine"
+      ]
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "general_variables": [
+          "availability"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "nervous_system"
+      ],
+      "lifestyle_and_behaviours": [
+        "sleep"
+      ],
+      "medication": [
+        "prescription"
+      ],
+      "general_variables": [
+        "physician_practitioner_info"
+      ],
+      "physiological_measurements": {
+        "anthropometry": [
+          "weight"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "ethnicity_race"
+      ]
+    }
+  },
+  {
+    "cohort_name": "WHI (Women's Health Initiative)",
+    "countries": [
+      "USA"
+    ],
+    "pi_lead": "Garnet Anderson",
+    "website": "https://deino.whiops.org/go/www.whi.org~ssl/SitePages/WHI%20Home.aspx",
+    "available_data_types": {
+      "genomic_data": true,
+      "environmental_data": true,
+      "biospecimens": true,
+      "phenotypic_clinical_data": true
+    },
+    "laboratory_measures": {
+      "genomics": {
+        "data_type": [
+          "other"
+        ],
+        "general_variables": [
+          "sample_size"
+        ]
+      }
+    },
+    "questionnaire_survey_data": {
+      "diseases": [
+        "oncological"
+      ],
+      "lifestyle_and_behaviours": [
+        "nutrition"
+      ],
+      "non_pharmacological_interventions": [
+        "surgical_interventions"
+      ],
+      "physiological_measurements": {
+        "cirulation_and_respiration": [
+          "heart_rate"
+        ]
+      },
+      "socio_demographic_and_economic_characteristics": [
+        "family_and_household_structure"
+      ]
+    },
+    "survey_administration": [
+      "date_and_time_related_information"
+    ]
+  }
+]

--- a/mappings/index.tsv
+++ b/mappings/index.tsv
@@ -1,7 +1,7 @@
 ID	Ontology Label	Preferred Label	Value	Class Type	Parent	Target	Output Of	Measurement Of	Information About	Comment																	
 ID	A alternative term	LABEL		CLASS_TYPE	C % SPLIT=|	C 'has target' some %	C 'output of' some %	C 'measurement of' some %	C 'is about' some %	A comment																	
 GECKO:9999998		CINECA																									
-GECKO:0000108		occupation			socio-demographic and economic characteristics				Occupation																		
+																											
 GECKO:0000093	medication	medication history			CINECA|clinical history																						
 GECKO:0000092		surgical interventions			CINECA																						
 GECKO:0000091		non-pharmacological interventions			CINECA|clinical history																						
@@ -28,7 +28,7 @@ GECKO:0000071		sleep		equivalent	clinical history				GO sleep
 GECKO:0000070		physical activity			CINECA																						
 GECKO:0000069		alcohol			CINECA																						
 GECKO:0000068		tobacco			CINECA																						
-					lifestyle and behaviours				Smoking																		
+GECKO:0000068					lifestyle and behaviours				Smoking																		
 GECKO:0000067		lifestyle and behaviours			CINECA																						
 GECKO:0000066		family and household structure			CINECA																						
 GECKO:0000065		education			CINECA																						
@@ -449,4 +449,5 @@ GECKO:1000142		occurrence of fever			signs and symptoms
 GECKO:1000143		occurrence of weight loss			signs and symptoms																						
 GECKO:1000144		occurrence of night sweats			signs and symptoms																						
 GECKO:1000145		history of medication for tuberculosis			disease(s) treated with medication																						
+GECKO:1000146		occupation			socio-demographic and economic characteristics				Occupation																		
 DOID:526	human immunodeficiency virus infectious disease	human immunodeficiency virus infectious disease			disease																						

--- a/src/cohort.html.jinja2
+++ b/src/cohort.html.jinja2
@@ -21,6 +21,24 @@
                     {% set country_field = 'Country' %}
                 {% endif %}
                 <p><b>{{ country_field }}:</b> {{ o.countries }}</p>
+                {% if o.current_enrollment %}
+                    {% set cur_enroll = '<p><b>Current Enrollment:</b> ' + o.current_enrollment + '</p>' %}
+                {% else %}
+                    {% set cur_enroll = '' %}
+                {% endif %}
+                {% if o.target_enrollment %}
+                    {% set target_enroll = '<p><b>Target Enrollment:</b> ' + o.target_enrollment + '</p>' %}
+                {% else %}
+                    {% set target_enroll = '' %}
+                {% endif %}
+                {% if o.enrollment_period %}
+                    {% set enroll_period = '<p><b>Enrollment Period:</b> ' + o.enrollment_period + '</p>' %}
+                {% else %}
+                    {% set enroll_period = '' %}
+                {% endif %}
+                {{ cur_enroll }}
+                {{ target_enroll }}
+                {{ enroll_period }}
                 <p><b>Data:</b> <a href="{{ o.data_dictionary }}">View data dictionary</a> | <a href="{{ o.mapping }}">View CINECA mapping</a></p>
                 <p><b>OWL:</b> <a href="{{ o.tree }}">View OWL tree</a> | <a href="{{ o.owl }}">Download OWL file</a></p>
             </div>

--- a/src/cohort.html.jinja2
+++ b/src/cohort.html.jinja2
@@ -16,29 +16,19 @@
                 <hr>
                 <p><b>PI Lead(s):</b> {{ o.pi_lead }}</p>
                 {% if ',' in o.countries %}
-                    {% set country_field = 'Countries' %}
+                    <p><b>Countries:</b> {{ o.countries }}</p>
                 {% else %}
-                    {% set country_field = 'Country' %}
+                    <p><b>Country:</b> {{ o.countries }}</p>
                 {% endif %}
-                <p><b>{{ country_field }}:</b> {{ o.countries }}</p>
                 {% if o.current_enrollment %}
-                    {% set cur_enroll = '<p><b>Current Enrollment:</b> ' + o.current_enrollment + '</p>' %}
-                {% else %}
-                    {% set cur_enroll = '' %}
+                    <p><b>Current Enrollment:</b> {{ o.current_enrollment }}</p>
                 {% endif %}
                 {% if o.target_enrollment %}
-                    {% set target_enroll = '<p><b>Target Enrollment:</b> ' + o.target_enrollment + '</p>' %}
-                {% else %}
-                    {% set target_enroll = '' %}
+                    <p><b>Target Enrollment:</b> {{ o.target_enrollment }}</p>
                 {% endif %}
                 {% if o.enrollment_period %}
-                    {% set enroll_period = '<p><b>Enrollment Period:</b> ' + o.enrollment_period + '</p>' %}
-                {% else %}
-                    {% set enroll_period = '' %}
+                    <p><b>Enrollment Period:</b> {{ o.enrollment_period }}</p>
                 {% endif %}
-                {{ cur_enroll }}
-                {{ target_enroll }}
-                {{ enroll_period }}
                 <p><b>Data:</b> <a href="{{ o.data_dictionary }}">View data dictionary</a> | <a href="{{ o.mapping }}">View CINECA mapping</a></p>
                 <p><b>OWL:</b> <a href="{{ o.tree }}">View OWL tree</a> | <a href="{{ o.owl }}">Download OWL file</a></p>
             </div>

--- a/src/create_cohort_html.py
+++ b/src/create_cohort_html.py
@@ -41,6 +41,16 @@ def main():
         cohort_data['tree'] = '../{0}-tree.html'.format(cohort_id)
         cohort_data['owl'] = '../{0}.owl'.format(cohort_id)
 
+        cur_enroll = cohort_data['current_enrollment']
+        target_enroll = cohort_data['target_enrollment']
+        if cur_enroll:
+            cur_enroll = "{:,}".format(cohort_data['current_enrollment'])
+        if target_enroll:
+            target_enroll = "{:,}".format(cohort_data['target_enrollment'])
+
+        cohort_data['current_enrollment'] = cur_enroll
+        cohort_data['target_enrollment'] = target_enroll
+
         template = Template(template_str)
         res = template.render(o=cohort_data)
 

--- a/src/index.html
+++ b/src/index.html
@@ -191,20 +191,47 @@ function createAggregations(data, gecko) {
     aggs.appendChild(div);
 }
 
-function addCohortSearchResults(tbody, data) {
+function addCohortSearchResults(tbody, data, cohorts_metadata) {
     for (var i = 0; i < data.length; i++) {
         var node = data[i];
+        var name = node.cohort_name;
+
+        var metadata = null;
+        if (cohorts_metadata[name]) {
+            metadata = cohorts_metadata[name];
+        }
+
+        var prefix = '';
+        if (metadata != null && metadata != undefined) {
+            prefix = metadata.prefix;
+        }
+
         var row = document.createElement("tr");
         row.setAttribute("class", "cohort-row");
-        row.setAttribute("id", node.prefix);
+        if (prefix != '') {
+            row.setAttribute("id", prefix);
+        }
 
         var nameCell = document.createElement("td");
         nameCell.setAttribute("class", "name-col");
         var a = document.createElement("a");
-        var cohort_page = cohort_pages[node.prefix];
-        a.setAttribute("href", cohort_page);
-        a.innerHTML = node.cohort_name;
-        nameCell.appendChild(a);
+        var cohort_page;
+        if (prefix != '' && cohort_pages.hasOwnProperty(prefix)) {
+            cohort_page = cohort_pages[prefix];
+            a.setAttribute("href", cohort_page);
+            a.innerHTML = name;
+            nameCell.appendChild(a);
+        } else {
+            cohort_page = node.website;
+            if (cohort_page != '') {
+                a.setAttribute("href", cohort_page);
+                a.innerHTML = name;
+                nameCell.appendChild(a);
+            } else {
+                nameCell.innerHTML = name;
+            }
+        }
+        
 
         var piCell = document.createElement("td");
         piCell.setAttribute("class", "pi-col");
@@ -215,7 +242,16 @@ function addCohortSearchResults(tbody, data) {
         countryCell.setAttribute("class", "country-col");
         countryCell.innerHTML = countries;
 
-        var datatypes = node.datatypes.join(', ');
+        var datatypes_list = [];
+        var available_data_types = node.available_data_types;
+        for (var key in available_data_types) {
+            // true or false value if this data is available
+            var val = available_data_types[key];
+            if (val) {
+                datatypes_list.push(key);
+            }
+        }
+        var datatypes = datatypes_list.join(', ');
         var dtCell = document.createElement("td");
         dtCell.setAttribute("class", "dt-col");
         dtCell.innerHTML = datatypes;
@@ -328,7 +364,7 @@ function addSearchResults(tbody, source, data) {
     }
 }
 
-function createCohortSearchResults(cohorts) {
+function createCohortSearchResults(cohorts, cohorts_metadata) {
     var res = document.getElementById("cohortsOnly");
 
     var wrapper = document.createElement("div");
@@ -372,7 +408,7 @@ function createCohortSearchResults(cohorts) {
     // Create the table body
     var tbody = document.createElement("tbody");
 
-    addCohortSearchResults(tbody, cohorts);
+    addCohortSearchResults(tbody, cohorts, cohorts_metadata);
 
     table.appendChild(tbody);
     wrapper.appendChild(table);
@@ -506,7 +542,10 @@ function filterTable(catMap, checked) {
             }
             var uniqueKeep = [...new Set(keep)];
             for (i = 0; i < uniqueKeep.length; i++) {
-                document.getElementById(uniqueKeep[i]).style.display = "";
+                var ele = document.getElementById(uniqueKeep[i]);
+                if (ele != null) {
+                    ele.style.display = "";
+                }
             }
         }
     }
@@ -631,7 +670,8 @@ createAggregations(cineca, gecko);
 createSearchResults(allDataSets);
 
 var cohorts = get_json('./cohorts.json');
-createCohortSearchResults(cohorts);
+var cohorts_metadata = get_json('./metadata.json');
+createCohortSearchResults(cohorts, cohorts_metadata);
 
 // Event listener for check box selections
 document.addEventListener("DOMContentLoaded", function (event) {

--- a/src/json/cineca_structure.json
+++ b/src/json/cineca_structure.json
@@ -1,0 +1,118 @@
+{
+	"basic cohort attributes": {
+		"demographic data": [
+			"age range",
+			"gender(s) studied in cohort",
+			"sex(es) studied in cohort"
+		],
+		"population data": [
+			"criteria for enrollment and recruitment procedures",
+			"location",
+			"num. participants"
+		],
+		"general_variables": [
+			"aims and objectives",
+			"data collection events",
+			"study design",
+			"timeline"
+		]
+	},
+	"biosample": {
+		"sample type": [
+			"blood",
+			"saliva",
+			"stool",
+			"urine"
+		],
+		"general_variables": ["storage method"]
+	},
+	"laboratory measures": {
+		"genomics": {
+			"data type": [
+				"DNA/Genotyping",
+				"Epigenetics",
+				"eQTL",
+				"Metagenomics",
+				"Microbiome markers",
+				"other",
+				"RNAseq/gene expression",
+				"Sequence variants",
+				"WES",
+				"WGS"
+			],
+			"general_variables": [
+				"associated cell type/tissue type/biosample",
+				"associated disease",
+				"associated medication",
+				"associated phenotype",
+				"availability",
+				"available data format(s)",
+				"processing method",
+				"sample size"
+			]
+		},
+		"microbiology": [
+			"biosample source/anatomical location",
+			"microbial data"
+		]
+	},
+	"questionnaire/survey data": {
+		"diseases": [
+			"blood-related disorders",
+			"circulatory system",
+			"digestive system",
+			"endocrine/nutritional/metabolic disorders",
+			"mental and behaviour disorders",
+			"nervous system",
+			"oncological",
+			"respiratory system"
+		],
+		"lifestyle and behaviours": [
+			"alcohol",
+			"nutrition",
+			"physical activity",
+			"sleep",
+			"tobacco"
+		],
+		"medication": [
+			"administration method",
+			"associated disease(s)",
+			"drug response(s)",
+			"posology",
+			"prescription"
+		],
+		"non-pharmacological interventions": ["surgical interventions"],
+		"physiological measurements": {
+			"anthropometry": [
+				"height",
+				"weight"
+			],
+			"cirulation and respiration": [
+				"blood pressure",
+				"heart rate"
+			]
+		},
+		"socio-demographic and economic characteristics": [
+			"age/birthdate",
+			"biological sex",
+			"birthplace",
+			"education",
+			"ethnicity/race",
+			"family and household structure",
+			"gender",
+			"genealogy",
+			"residence"
+		],
+		"general_variables": [
+			"life stage/time point",
+			"physician/practitioner info",
+			"signs and symptoms"
+		]
+	},
+	"statistics": ["summary statistics for additional data from federated sources"],
+	"survey administration": [
+		"consent/accessibility",
+		"date and time-related information",
+		"unique identifiers"
+	]
+}

--- a/src/json/generate_cohort_json.py
+++ b/src/json/generate_cohort_json.py
@@ -108,7 +108,8 @@ def clean_dict(d):
 
 
 def clean_string(string):
-    return string.replace(' ', '_').replace('-', '_').replace('/', '_')
+    return string.replace(
+        ' ', '_').replace('-', '_').replace('/', '_').replace('(', '').replace(')', '').replace('.', '')
 
 
 def get_children(gin, node):

--- a/src/json/generate_cohort_json.py
+++ b/src/json/generate_cohort_json.py
@@ -5,32 +5,27 @@ import rdflib
 from argparse import ArgumentParser, FileType
 
 master_map = {}
-
-ttl_files = {'KoGES': 'build/mapping/gecko-koges.ttl',
-             'GCS': 'build/mapping/gecko-gcs.ttl',
-             'GE': 'build/mapping/genomics-england-gecko.ttl',
-             'SAPRIN': 'build/mapping/saprin-gecko.ttl',
-             'VZ': 'build/mapping/vukuzazi-gecko.ttl'}
-
-names = {'KoGES': 'Korean Genome and Epidemiology Study (KoGES)',
-            'GCS': 'Golestan Cohort Study',
-            'GE': 'Genomics England / 100,000 Genomes Project',
-            'SAPRIN': 'SAPRIN (South African Population Research Infrastructure Network)',
-            'VZ': 'Africa Health Research Institute (AHRI) Population Cohort'}
-
 ignore_variables = ['venous or arterial', 'fasting or non-fasting', 'DNA/Genotyping', 'WGS', 'WES', 'Sequence variants',
                     'Epigenetics', 'Metagenomics', 'Microbiome markers', 'RNAseq/gene expression', 'eQTL', 'other']
+general_variables = ['signs and symptoms']
 
 
 def main():
     global master_map
     parser = ArgumentParser(description='TODO')
-    parser.add_argument('cohorts', type=FileType('r'))
+    parser.add_argument('cohorts_csv', type=FileType('r'))
+    parser.add_argument('cohorts_metadata', type=FileType('r'))
+    parser.add_argument('cineca', type=FileType('r'))
     parser.add_argument('output', type=FileType('w'), help='output JSON')
 
     args = parser.parse_args()
-    cohorts_file = args.cohorts
+    cohorts_file = args.cohorts_csv
+    metadata_file = args.cohorts_metadata
+    cineca_file = args.cineca
     output_file = args.output
+
+    metadata = json.loads(metadata_file.read())
+    cineca = json.loads(cineca_file.read())
 
     cohort_data = {}
     reader = csv.reader(cohorts_file)
@@ -44,33 +39,35 @@ def main():
         environment = row[7]
         biospecimen = row[8]
         clinical = row[9]
-        datatypes = []
+        datatypes = {'genomic_data': False,
+                     'environmental_data': False,
+                     'biospecimens': False,
+                     'phenotypic_clinical_data': False}
         if genomic == 'Yes':
-            datatypes.append('Genomic Data')
+            datatypes['genomic_data'] = True
         if environment == 'Yes':
-            datatypes.append('Environmental Data')
+            datatypes['environmental_data'] = True
         if biospecimen == 'Yes':
-            datatypes.append('Biospecimens')
+            datatypes['biospecimens'] = True
         if clinical == 'Yes':
-            datatypes.append('Phenotypic/Clinical Data')
+            datatypes['phenotypic_clinical_data'] = True
 
         cohort_data[row[0]] = {'cohort_name': row[0],
                                'countries': countries,
                                'pi_lead': row[1],
                                'website': row[11],
-                               'datatypes': datatypes}
+                               'available_data_types': datatypes}
 
     all_data = []
-    for prefix, cohort_name in names.items():
-        file_name = ttl_files[prefix]
+    for cohort_name, cohort_metadata in metadata.items():
+        file_name = 'build/mapping/{0}-gecko.ttl'.format(cohort_metadata['id'].lower())
         gin = rdflib.Graph()
         gin.parse(file_name, format='turtle')
         child_to_parent = get_children(gin, 'http://example.com/GECKO_9999998')
         master_map = {}
-        data = get_data(child_to_parent)
+        data = get_categories(child_to_parent, cineca)
         if cohort_name in cohort_data:
-            this_cohort = {'prefix': prefix}
-            this_cohort.update(cohort_data[cohort_name])
+            this_cohort = cohort_data[cohort_name]
             this_cohort.update(data)
             all_data.append(this_cohort)
 
@@ -79,12 +76,47 @@ def main():
     output_file.close()
 
 
-def get_children(gin, node):
-    """
+def build_nested(nested_dict, reverse_path):
+    """Build a nested dictionary from a reveresed path (lowest level -> highest level)
 
-    :param gin:
-    :param node:
-    :return:
+    :param nested_dict: starting dictionary
+    :param reverse_path: path from current level up
+    :return: nested dictionary from path
+    """
+    cur_level = reverse_path.pop(0)
+    new_dict = {cur_level: nested_dict}
+    if reverse_path:
+        return build_nested(new_dict, reverse_path)
+    else:
+        return new_dict
+
+
+def clean_dict(d):
+    """Clean dictionary by replacing any spaces and special characters in keys and values with underscores.
+
+    :param d: dictionary to clean
+    :return: cleaned dictionary
+    """
+    new = {}
+    for k, v in d.items():
+        if isinstance(v, dict):
+            v = clean_dict(v)
+        if isinstance(v, list):
+            v = [clean_string(x) for x in v]
+        new[clean_string(k)] = v
+    return new
+
+
+def clean_string(string):
+    return string.replace(' ', '_').replace('-', '_').replace('/', '_')
+
+
+def get_children(gin, node):
+    """Get map of child -> parent terms.
+
+    :param gin: rdflib Graph
+    :param node: node to get children of
+    :return: map of child -> parent terms
     """
     nodes = {}
     query = '''SELECT ?s ?label ?parent
@@ -112,69 +144,88 @@ def get_children(gin, node):
     return nodes
 
 
-def get_data(child_to_parent):
+def get_categories(child_to_parent, cineca):
+    """Get the CINECA categories used in a cohort as structured dictionary.
+
+    :param child_to_parent: map of all children to their parent terms
+    :param cineca: CINECA structure
+    :return: subset of CINECA structure consisting of only categories used in this cohort
+    """
     global master_map
-    bottom_level = {}
+    bottom_level = []
     for child, parent in child_to_parent.items():
         if child not in child_to_parent.values():
-            if parent in bottom_level:
-                children = bottom_level[parent]
-            else:
-                children = {}
-            children[child] = {}
-            bottom_level[parent] = children
+            bottom_level.append(child)
 
-    build_map(bottom_level, child_to_parent)
-    clean(master_map)
-    return master_map['CINECA']
-
-
-def build_map(current_level, child_to_parent):
-    global master_map
-
-    next_level = {}
-    for parent, children in current_level.items():
-        if parent == 'CINECA':
-            if 'CINECA' in current_level:
-                master_map = merge(current_level, master_map)
-            else:
-                master_map = merge({'CINECA': current_level}, master_map)
-
-        if parent in child_to_parent:
-            next_parent = child_to_parent[parent]
-            if next_parent in next_level:
-                next_children = next_level[next_parent]
-            else:
-                next_children = {}
-            next_children.update({parent: children})
-
-            next_level[next_parent] = next_children
-            build_map(next_level, child_to_parent)
+    subset = {}
+    for leaf in bottom_level:
+        result = get_path(cineca, leaf)
+        if result is None:
+            print('ERROR - unable to find "{0}"'.format(leaf))
+            continue
+        path = result[0]
+        if path is None:
+            print('ERROR - unable to find "{0}"'.format(leaf))
+            continue
+        has_children = result[1]
+        path.reverse()
+        if has_children:
+            cur_level = path.pop(0)
+            new_dict = build_nested({cur_level: None}, path)
+        else:
+            cur_level = path.pop(0)
+            new_dict = build_nested([cur_level], path)
+        subset = merge(new_dict, subset)
+    return clean_dict(subset)
 
 
-def merge(source, destination):
+def merge(source, target):
+    """Merge a source dictionary into a target dictionary
+
+    :param source: source dictionary
+    :param target: target dictionary
+    :return: source merged into target
+    """
     for key, value in source.items():
         if isinstance(value, dict):
             # get node or create one
-            node = destination.setdefault(key, {})
+            node = target.setdefault(key, {})
             merge(value, node)
         else:
-            destination[key] = value
+            target[key] = value
 
-    return destination
+    return target
 
 
-def clean(dictionary):
-    for key, value in dictionary.items():
-        list_items = []
-        for k, v in value.items():
-            if not v:
-                list_items.append(k)
-        if list_items:
-            dictionary[key] = list_items
-        else:
-            clean(value)
+def get_path(haystack, needle, path=None):
+    """Search a nested dictionary for the path to a specific value.
+    The value may be a key in a dict or a value in a list.
 
+    :param haystack: nested dictionary to search
+    :param needle: string value to search for
+    :param path: pre-path
+    :return: path to value as list
+    """
+    if path is None:
+        path = []
+    if isinstance(haystack, dict):
+        if needle in haystack:
+            # Value is a key and has children
+            path.append(needle)
+            return path, True
+        for k, v in haystack.items():
+            # Value not yet found
+            result = get_path(v, needle, path + [k])
+            if result is not None:
+                return result
+    elif isinstance(haystack, list):
+        # Value is in a list and does not have children
+        if needle in haystack:
+            path.append(needle)
+            return path, False
+    else:
+        # Value is not in this path
+        return None, None
 
 
 if __name__ == '__main__':

--- a/src/json/generate_cohort_json.py
+++ b/src/json/generate_cohort_json.py
@@ -52,10 +52,26 @@ def main():
         if clinical == 'Yes':
             datatypes['phenotypic_clinical_data'] = True
 
+        cur_enroll = row[3].replace(',', '').strip()
+        target_enroll = row[4].replace(',', '').strip()
+
+        if cur_enroll == '':
+            cur_enroll = None
+        else:
+            cur_enroll = int(cur_enroll)
+
+        if target_enroll == '':
+            target_enroll = None
+        else:
+            target_enroll = int(target_enroll)
+
         cohort_data[row[0]] = {'cohort_name': row[0],
                                'countries': countries,
                                'pi_lead': row[1],
                                'website': row[11],
+                               'current_enrollment': cur_enroll,
+                               'target_enrollment': target_enroll,
+                               'enrollment_period': row[5],
                                'available_data_types': datatypes}
 
     all_data = []


### PR DESCRIPTION
This includes fixes to the cohort data structure for #44, as well as two new `data` files:
* `data/random-data.json`: All remaining member cohorts with randomly-selected CINECA categories
* `data/full-cohort-data.json`: The real data (`data/cohort-data.json`) plus the random data

These fake-data populated cohorts will show up in the cohort-only view of the browser, but they will not show up for filtering selections. Only the ones we've mapped data will show up in this.

Cohort data also now includes three extra fields from the IHCC data:
* Current enrollment
* Target enrollment
* Enrollment period